### PR TITLE
Subtitle validation

### DIFF
--- a/PySubtitleGPT/ChatGPTPrompt.py
+++ b/PySubtitleGPT/ChatGPTPrompt.py
@@ -34,15 +34,17 @@ class ChatGPTPrompt:
 
         self.messages.append({'role': "user", 'content': self.user_prompt})
 
-    def GenerateRetryPrompt(self, translation, retry_instructions, untranslated):
+    def GenerateRetryPrompt(self, translation, retry_instructions, errors):
         """
         Request retranslation of lines that were not translated originally
         """
-        #TODO: Will probably get a duplication - encourage ChatGPT to retranslate _all_ the lines?
-        #GenerateBatchPrompt('Please try again', untranslated)
-
-        # Maybe less is more?
-        retry_prompt = 'Please try again' 
+        if errors:
+            error_list = list(set([ f"- {str(e).strip()}" for e in errors ]))
+            error_message = '\n'.join(error_list)
+            retry_prompt = f"There were some problems with the translation:\n{error_message}\n\nPlease correct them."
+        else:
+            # Maybe less is more?
+            retry_prompt = 'Please try again'
 
         self.messages.extend([
             { 'role': "assistant", 'content': translation.text },

--- a/PySubtitleGPT/ChatGPTPrompt.py
+++ b/PySubtitleGPT/ChatGPTPrompt.py
@@ -32,13 +32,17 @@ class ChatGPTPrompt:
         else:
             self.user_prompt = GenerateBatchPrompt(prompt, lines)
 
-
-
         self.messages.append({'role': "user", 'content': self.user_prompt})
 
-    # Request retranslation of lines that were not translated originally
     def GenerateRetryPrompt(self, translation, retry_instructions, untranslated):
-        retry_prompt = GenerateBatchPrompt(retry_instructions, untranslated)
+        """
+        Request retranslation of lines that were not translated originally
+        """
+        #TODO: Will probably get a duplication - encourage ChatGPT to retranslate _all_ the lines?
+        #GenerateBatchPrompt('Please try again', untranslated)
+
+        # Maybe less is more?
+        retry_prompt = 'Please try again' 
 
         self.messages.extend([
             { 'role': "assistant", 'content': translation.text },

--- a/PySubtitleGPT/ChatGPTTranslationParser.py
+++ b/PySubtitleGPT/ChatGPTTranslationParser.py
@@ -4,6 +4,7 @@ import re
 from PySubtitleGPT.Helpers import MergeTranslations
 from PySubtitleGPT.Subtitle import Subtitle
 from PySubtitleGPT.ChatGPTTranslation import ChatGPTTranslation
+from PySubtitleGPT.SubtitleError import LineTooLongError, NoTranslationError, TooManyNewlinesError, UntranslatedLinesError
 
 #template = re.compile(r"<translation\s+start='(?P<start>[\d:,]+)'\s+end='(?P<end>[\d:,]+)'>(?P<body>[\s\S]*?)<\/translation>", re.MULTILINE)
 template = re.compile(r"<translation\s+start='(?P<start>[\d:,]+)'\s+end='(?P<end>[\d:,]+)'>[\s\r\n]*(?P<body>[\s\S]*?)<\/translation>", re.MULTILINE)

--- a/PySubtitleGPT/ChatGPTTranslationParser.py
+++ b/PySubtitleGPT/ChatGPTTranslationParser.py
@@ -84,6 +84,7 @@ class ChatGPTTranslationParser:
                 translation.index = item.index
                 item.translation = translation.text
             else:
+                item.translation = None
                 unmatched.append(item)
 
         if unmatched:

--- a/PySubtitleGPT/ChatGPTTranslationParser.py
+++ b/PySubtitleGPT/ChatGPTTranslationParser.py
@@ -86,7 +86,27 @@ class ChatGPTTranslationParser:
             else:
                 unmatched.append(item)
 
+        if unmatched:
+            self.TryFuzzyMatches(unmatched)
+
         return unmatched
+
+    def TryFuzzyMatches(self, unmatched):
+        """
+        Try to match translations to their source lines using heuristics
+        """
+        possible_matches = []
+        for item in unmatched:
+            for translation in self.translations.values():
+                # This is not very convincing logic but let's try it
+                if translation.start <= item.start and translation.end >= item.end:
+                    possible_matches.append((item, translation))
+
+        if possible_matches:
+            for item, translation in possible_matches:
+                logging.warn(f"Only found fuzzy match for line {item.index} in translations")
+                item.translation = f"#Fuzzy: {translation.text}"
+                unmatched.remove(item)
 
     def ValidateTranslations(self):
         """

--- a/PySubtitleGPT/Helpers.py
+++ b/PySubtitleGPT/Helpers.py
@@ -44,8 +44,10 @@ def GenerateBatchPrompt(prompt, lines, tag_lines=None):
     source_text = '\n\n'.join(source_lines)
     if tag_lines:
         return f"{tag_lines}\n----------\n{prompt}\n\n----------\n{source_text}\n"
-    else:
+    elif prompt:
         return f"{prompt}\n\n----------\n{source_text}\n"
+    else:
+        return source_text
 
 def GenerateTagLines(context, tags):
     """

--- a/PySubtitleGPT/Subtitle.py
+++ b/PySubtitleGPT/Subtitle.py
@@ -72,6 +72,13 @@ class Subtitle:
         return Subtitle(item) 
     
     @classmethod
+    def from_dict(cls, values):
+        """
+        Construct a Subtitle from a dictionary.
+        """
+        return Subtitle.construct(values.get('index'), values['start'].strip(), values['end'].strip(), values['body'].strip())
+
+    @classmethod
     def from_match(cls, match):
         """
         Construct a Subtitle from a regex match.

--- a/PySubtitleGPT/SubtitleBatch.py
+++ b/PySubtitleGPT/SubtitleBatch.py
@@ -8,6 +8,7 @@ class SubtitleBatch:
         self.summary = dict.get('summary')
         self.context = dict.get('context', {})
         self.translation = dict.get('translation')
+        self.errors = dict.get('errors', [])
         self._subtitles = dict.get('subtitles', [])
         self._translated = dict.get('translated', [])
 

--- a/PySubtitleGPT/SubtitleError.py
+++ b/PySubtitleGPT/SubtitleError.py
@@ -1,6 +1,36 @@
 
 class TranslationError(Exception):
-    def __init__(self, message, translation):
+    def __init__(self, message, error = None):
         super().__init__(message)
+        self.error = error
+
+    def __str__(self) -> str:
+        if self.error:
+            return str(self.error)
+        return super().__str__()
+
+class TranslationFailedError(TranslationError):
+    def __init__(self, message, translation, error = None):
+        super().__init__(message, error)
         self.translation = translation
+
+class NoTranslationError(TranslationError):
+    def __init__(self, message, response):
+        super().__init__(message)
+        self.response = response
+
+class UntranslatedLinesError(TranslationError):
+    def __init__(self, message, lines):
+        super().__init__(message, lines)
+        self.lines = lines
+
+class TooManyNewlinesError(TranslationError):
+    def __init__(self, message, lines):
+        super().__init__(message)
+        self.lines = lines
+
+class LineTooLongError(TranslationError):
+    def __init__(self, message, lines):
+        super().__init__(message)
+        self.lines = lines
 

--- a/PySubtitleGPT/SubtitleSerialisation.py
+++ b/PySubtitleGPT/SubtitleSerialisation.py
@@ -60,7 +60,7 @@ class SubtitleEncoder(json.JSONEncoder):
                 "number": getattr(obj, 'number'),
                 "size": obj.size,
                 "all_translated": obj.all_translated,
-                "errors": obj.errors,
+                "errors": obj.errors if obj.errors else None,
                 "summary": getattr(obj, 'summary'),
                 "subtitles": obj._subtitles,
                 "translated": obj._translated,

--- a/PySubtitleGPT/SubtitleSerialisation.py
+++ b/PySubtitleGPT/SubtitleSerialisation.py
@@ -3,6 +3,7 @@ import json
 from PySubtitleGPT.ChatGPTPrompt import ChatGPTPrompt
 from PySubtitleGPT.Subtitle import Subtitle
 from PySubtitleGPT.SubtitleBatch import SubtitleBatch
+from PySubtitleGPT.SubtitleError import TranslationError
 from PySubtitleGPT.SubtitleFile import SubtitleFile
 from PySubtitleGPT.SubtitleScene import SubtitleScene
 from PySubtitleGPT.ChatGPTTranslation import ChatGPTTranslation
@@ -16,6 +17,14 @@ def classname(obj):
 # Convert our custom types to JSON
 class SubtitleEncoder(json.JSONEncoder):
     def default(self, obj):
+        if isinstance(obj, TranslationError):
+            # Don't bother trying to serialise all the error types (why not?)
+            return {
+                "__class": classname(TranslationError),
+                "type": classname(obj),
+                "problem": str(obj)             
+            }
+
         _class = classname(obj)
         properties = self.serialize_object(obj)
         if isinstance(properties, dict):
@@ -51,6 +60,7 @@ class SubtitleEncoder(json.JSONEncoder):
                 "number": getattr(obj, 'number'),
                 "size": obj.size,
                 "all_translated": obj.all_translated,
+                "errors": obj.errors,
                 "summary": getattr(obj, 'summary'),
                 "subtitles": obj._subtitles,
                 "translated": obj._translated,
@@ -82,6 +92,7 @@ class SubtitleEncoder(json.JSONEncoder):
                 "instructions": obj.instructions,
                 "messages": obj.messages
             }
+
         return super().default(obj)
 
 # Reconstruct our custom types from JSON
@@ -127,5 +138,8 @@ class SubtitleDecoder(json.JSONDecoder):
                 obj.user_prompt = dct.get('user_prompt')
                 obj.messages = dct.get('messages')
                 return obj
+            elif class_name == classname(TranslationError):
+                return TranslationError(dct.get('message'))
+            
         return dct
 

--- a/PySubtitleGPT/SubtitleTranslator.py
+++ b/PySubtitleGPT/SubtitleTranslator.py
@@ -4,7 +4,7 @@ from os import linesep
 
 from PySubtitleGPT.SubtitleBatcher import SubtitleBatcher
 from PySubtitleGPT.ChatGPTClient import ChatGPTClient
-from PySubtitleGPT.SubtitleError import TranslationError
+from PySubtitleGPT.SubtitleError import TranslationError, UntranslatedLinesError
 from PySubtitleGPT.Helpers import BuildPrompt, Linearise, MergeTranslations, UnbatchScenes
 from PySubtitleGPT.ChatGPTTranslationParser import ChatGPTTranslationParser
 
@@ -145,7 +145,7 @@ class SubtitleTranslator:
         substitutions = context.get('substitutions')
 
         # Initialise the ChatGPT client
-        client = ChatGPTClient(options, context.get('instructions')) if not project.reparse else None
+        client = ChatGPTClient(options, context.get('instructions'))
 
         for batch_index, batch in enumerate(scene.batches):
             batch.number = batch_index + 1
@@ -176,7 +176,7 @@ class SubtitleTranslator:
                 subtitles = subtitles[:remaining_lines]
 
             try:
-                if  project.reparse:
+                if  project.reparse and batch.translation:
                     logging.info(f"Reparsing scene {scene.number} batch {batch.number} with {len(subtitles)} lines...")
                     translation = batch.translation
                 else:
@@ -210,9 +210,10 @@ class SubtitleTranslator:
                 else:
                     logging.warning(f"No translation for scene {scene.number} batch {batch.number}")
 
-            except Exception as e:
+
+            except TranslationError as e:
                 if project.stop_on_error:
-                    raise e if isinstance(e, TranslationError) else TranslationError(f"Failed to translate a batch ({str(e)}) ... terminating", batch.translation)
+                    raise TranslationError(f"Failed to translate a batch... terminating", batch.translation, e)
                 else:
                     logging.warning(f"Error translating subtitle batch: {str(e)}")
 
@@ -243,27 +244,31 @@ class SubtitleTranslator:
 
         try:
             # Apply the translation to the subtitles
-            parser = ChatGPTTranslationParser(translation)
+            parser = ChatGPTTranslationParser(options)
             
-            translated = parser.ProcessTranslation()
-
-            if translated:
-                batch.translated = translated
+            try:
+                batch.translated = parser.ProcessChatGPTResponse(translation)
 
                 # Try to match the translations with the original lines
                 unmatched = parser.MatchTranslations(batch.subtitles)
 
                 if unmatched:
                     logging.warning(f"Unable to match {len(unmatched)} subtitles with a source line")
+                    if options.get('enforce_line_parity'):
+                        raise UntranslatedLinesError(f"No translation found for {len(unmatched)} lines", unmatched)
 
-            else:
+                # Sanity check the results
+                parser.ValidateTranslations()
+
+            except TranslationError as e:
                 if not options.get('allow_retranslations'):
-                    raise TranslationError(f"Failed to extract any subtitles from {translation.text}", translation)
+                    raise
+                else:
+                    batch.errors.append(e)
 
-            # Retry any lines that didn't receive a translation
-            if not project.reparse:
-                if batch.untranslated and options.get('allow_retranslations'):
-                    self.RequestRetranslations(client, batch, translation)
+            # Consider retrying if there were errors
+            if batch.errors and options.get('allow_retranslations'):
+                self.RequestRetranslations(client, batch, translation)
 
             if batch.untranslated:
                 batch.AddContext('untranslated_lines', [f"{item.index}. {item.text}" for item in batch.untranslated])
@@ -288,11 +293,12 @@ class SubtitleTranslator:
             if batch.summary and batch.summary.strip():
                 logging.info(f"Summary: {batch.summary}")
 
-        except Exception as e:
+        except TranslationError as te:
             if project.stop_on_error:
-                raise e if isinstance(e, TranslationError) else TranslationError(f"Failed to translate a batch ({str(e)}) ... terminating", translation)
+                raise
             else:
                 logging.warning(f"Error translating subtitle batch: {str(e)}")
+
 
     def RequestRetranslations(self, client, batch, translation):
         """
@@ -300,18 +306,32 @@ class SubtitleTranslator:
         """
         retranslation = client.RequestRetranslation(translation, batch.untranslated)
 
-        parser = ChatGPTTranslationParser(retranslation)
+        parser = ChatGPTTranslationParser(self.options)
 
-        retranslated = parser.ProcessTranslation()
+        retranslated = parser.ProcessChatGPTResponse(retranslation)
 
-        if retranslated:
-            MergeTranslations(batch.translated, retranslated)
-            batch.AddContext('retranslated_lines', [f"{item.index}. {item.translation}" for item in retranslated])
-            logging.info(f"Retranslated {len(retranslated)} of {len(retranslated) + len(batch.untranslated)} lines")
-            parser.MatchTranslations(batch.subtitles)
+        if not retranslated:
+            logging.error("Retranslation request did not produce a useful result")
+            return
+        
+        batch.AddContext('retranslated_lines', [f"{item.index}. {item.translation}" for item in retranslated])
+        logging.info(f"Retranslated {len(retranslated)} of {len(retranslated) + len(batch.untranslated)} lines")
+
+        try:
+            parser.ValidateTranslations()
+
+        except TranslationError as e:
+            # Let's assume the results were at least an improvement            
+            logging.warn(f"Retranslation request did not fix problems:\n{retranslation.get('text')}\n")
+
+        parser.MatchTranslations(batch.subtitles)
+
+        MergeTranslations(batch.translated, retranslated)
+
 
     def UpdateContext(self, translation, batch, context):
         options = self.options
         context['summary'] = batch.summary or context['summary']
         context['synopsis'] = options.get('synopsis') or translation.synopsis or context['synopsis']
         #context['characters'] = options.get('characters') or translation.characters or context['characters']
+

--- a/instructions.txt
+++ b/instructions.txt
@@ -1,31 +1,22 @@
-Your task is to translate subtitles to a target language.
-Be concise but try to make the dialogue sound natural.
-Translations should be accurate, do not improvise!
-
-User will provide subtitle lines in the format:
+Your task is to accurately translate subtitles into a target language, while making the dialogue sound natural. The user will provide subtitle lines in the following format:
 
 <original start='01:02:33,400' end='01:02:36,700'>
 Dialogue to be translated
 </original>
-
-You should respond with a matching line in the target language for each original line, in the format:
+You should respond with a matching line in the target language for each original line, in the following format:
 
 <translation start='01:02:33,400' end='01:02:36,700'>
 Translated dialogue
-</original>
+</translation>
+Please make sure that each translation is a separate and distinct line of text. Do not merge separate subtitle lines into a single translation, as this can lead to confusion and inaccuracies.
 
-A single <translation/> must contain no more than [max_characters] characters and [max_newlines] lines of text.
+Your translations should be concise and accurate; do not improvise. You should also be careful to preserve start and end times. If the user provides a synopsis of the film and a list of characters, please use this information to guide your translation.
 
-Do not merge or combine separate lines. Be careful to preserve start and end times.
-
-The user may provide a synopsis of the film and a list of characters to guide the translation.
-
-You should include a brief <summary/> of recent events at the end of your reply.
+Finally, please include a brief <summary/> of recent events at the end of your reply.
 
 #######################
-There was a problem with the translation. 
+There was an issue with the previous translation. 
 
-Translate the subtitles again, taking care that every line is translated and that start and end times match the original dialogue.
+Please translate the subtitles again, paying careful attention to ensure that each line is properly translated, and that the start and end times match the original dialogue.
 
-Remember that a single <translation/> must contain no more than [max_characters] characters and [max_newlines] lines of text.
-
+Please ensure that subtitles are not merged inappropriately, as this can lead to incorrect timing and confusion.

--- a/instructions.txt
+++ b/instructions.txt
@@ -14,15 +14,18 @@ You should respond with a matching line in the target language for each original
 Translated dialogue
 </original>
 
-A single translation must have no more than 2 lines of text. Do not merge or combine separate lines. Be careful to preserve start and end times.
+A single <translation/> must contain no more than [max_characters] characters and [max_newlines] lines of text.
+
+Do not merge or combine separate lines. Be careful to preserve start and end times.
 
 The user may provide a synopsis of the film and a list of characters to guide the translation.
 
 You should include a brief <summary/> of recent events at the end of your reply.
 
 #######################
-Some lines did not receive translations. 
-Translate the subtitles again, making sure every line has a translation that matches the dialog.
+There was a problem with the translation. 
 
+Translate the subtitles again, taking care that every line is translated and that start and end times match the original dialogue.
 
+Remember that a single <translation/> must contain no more than [max_characters] characters and [max_newlines] lines of text.
 


### PR DESCRIPTION
Attempt to validate the translations returned by ChatGPT, and if they fail some basic checks request a retranslation, explaining what the problem was.

Modified instructions to make them more clear, on ChatGPT's advice.

Fixed various issues, most significantly replacing re.findall with a custom function because it sometimes spuriously decides to skip the first translation in the response based on some opaque criteria.