### PR TITLE
Send list of summaries instead of lines

### DIFF
--- a/PySubtitleGPT/Options.py
+++ b/PySubtitleGPT/Options.py
@@ -29,6 +29,7 @@ default_options = {
     'batch_threshold': float(os.getenv('BATCH_THRESHOLD', 3.0)),
     'min_batch_size': int(os.getenv('MIN_BATCH_SIZE', 5)),
     'max_batch_size': int(os.getenv('MAX_BATCH_SIZE', 20)),
+    'max_context_summaries': int(os.getenv('MAX_CONTEXT_SUMMARIES', 10)),
     'max_characters': int(os.getenv('MAX_CHARACTERS', 120)),
     'max_newlines': int(os.getenv('MAX_NEWLINES', 3)),
     'max_lines': int(os.getenv('MAX_LINES')) if os.getenv('MAX_LINES') else None, 

--- a/PySubtitleGPT/SubtitleSerialisation.py
+++ b/PySubtitleGPT/SubtitleSerialisation.py
@@ -51,7 +51,8 @@ class SubtitleEncoder(json.JSONEncoder):
                 "linecount": obj.linecount,
                 "all_translated": obj.all_translated,
                 "context": {
-                    "summary": obj.context.get('summary')
+                    "summary": obj.context.get('summary'),
+                    "summaries": obj.context.get('summaries')
                 },
                 "batches": obj._batches,
             }
@@ -111,8 +112,8 @@ class SubtitleDecoder(json.JSONDecoder):
             elif class_name == classname(SubtitleScene):
                 obj = SubtitleScene()
                 obj.number = dct.get('number')
-                obj.context = dct.get('context')
-                obj._batches = dct.get('batches')
+                obj.context = dct.get('context') or {}
+                obj._batches = dct.get('batches') or []
                 obj._summary = dct.get('summary')
                 return obj
             elif class_name == classname(SubtitleBatch):

--- a/instructions.txt
+++ b/instructions.txt
@@ -1,23 +1,24 @@
-Your task is to accurately translate subtitles into a target language, while making the dialogue sound natural. The user will provide subtitle lines in the following format:
+Your task is to accurately translate subtitles into a target language. The user will provide subtitle lines in the following format:
 
 <original start='01:02:33,400' end='01:02:36,700'>
 Dialogue to be translated
 </original>
+
 You should respond with a matching line in the target language for each original line, in the following format:
 
 <translation start='01:02:33,400' end='01:02:36,700'>
 Translated dialogue
 </translation>
-Please make sure that each translation is a separate and distinct line of text. Do not merge separate subtitle lines into a single translation, as this can lead to confusion and inaccuracies.
 
-Your translations should be concise and accurate; do not improvise. You should also be careful to preserve start and end times. If the user provides a synopsis of the film and a list of characters, please use this information to guide your translation.
+Do not merge subtitles into a single translation as this can lead to confusion and inaccuracies.
 
-Finally, please include a brief <summary/> of recent events at the end of your reply.
+Your translations should be concise and accurate, whilst sounding natural; do not improvise. Be careful to preserve start and end times. 
+
+If the user provides a synopsis of the film or a list of characters, use them to guide your translation.
+
+Include a brief <summary/> of recent events at the end of each reply.
 
 #######################
 There was an issue with the previous translation. 
 
-Please translate the subtitles again, paying careful attention to ensure that each line is properly translated, and that the start and end times match the original dialogue.
-
-Do not merge multiple original lines into a single translation, it can lead to incorrect timing and confusion. Keep each translation line separate and corresponding to its original line.
-
+Please translate the subtitles again, paying careful attention to ensure that each line is translated separately, and that start and end times match the original dialogue. Do not merge lines, it can lead to incorrect timing and confusion.


### PR DESCRIPTION
Instead of sending the last batch of translated lines, maintain a list of recent summaries and send them, allowing a larger context to be developed.

This seems to work well, but need to keep an eye on it.