### PR TITLE
Fix some GUI-related issues

### DIFF
--- a/GUI/ProjectActions.py
+++ b/GUI/ProjectActions.py
@@ -130,8 +130,8 @@ class ProjectActions(QObject):
             self._issue_command(MergeScenesCommand(selection.scene_numbers, datamodel))
 
         elif selection.OnlyBatches():
-            scene_number = selection.batch_numbers[0][0]
-            batch_numbers = [ batch[1] for batch in selection.batch_numbers ]
+            scene_number = selection.selected_batches[0].scene
+            batch_numbers = [ batch.number for batch in selection.selected_batches ]
             self._issue_command(MergeBatchesCommand(scene_number, batch_numbers, datamodel))
 
         elif selection.AnyLines():

--- a/GUI/ProjectSelection.py
+++ b/GUI/ProjectSelection.py
@@ -180,9 +180,10 @@ class ProjectSelection():
                     self.AppendItem(model, child_index, False)
 
         elif isinstance(item, BatchItem):
-            if selected or not item.number in self.batches.keys():
+            key = (item.scene, item.number)
+            if selected or not key in self.batches:
                 batch = SelectionBatch(item, selected)
-                self.batches[item.number] = batch
+                self.batches[key] = batch
                 if not self.scenes.get(item.scene):
                     self.AppendItem(model, model.parent(index), False)
 

--- a/PySubtitleGPT/SubtitleScene.py
+++ b/PySubtitleGPT/SubtitleScene.py
@@ -89,6 +89,7 @@ class SubtitleScene:
         
         merged_batch = SubtitleBatch()
         merged_batch.number = batches[0].number
+        merged_batch.scene = self.number
         merged_batch.summary = "\n".join(batch.summary for batch in batches if batch.summary)
         merged_batch.originals = [ line for batch in batches for line in batch.originals ]
         merged_batch.translated = [ line for batch in batches for line in batch.translated ]


### PR DESCRIPTION
This pull request fixes some GUI-related issues. The [third commit](https://github.com/machinewrapped/gpt-subtrans/pull/14/commits/b8a4a5134bae64781553663257047e7fcc8a0514) changes the invariant of the unique `number` value in `ProjectSelection.batches` (it allows batches with the same `number` but different `scene` to coexist in this dict). If this invariant is relied upon somewhere, it may cause other issues.

For the [first commit](https://github.com/machinewrapped/gpt-subtrans/pull/14/commits/01a84ab541006597c92475e217e416871ef5c31c), I speculate that this issue may be due to the behavior where selecting a Batch adds all Batches belonging to the Scene under `ProjectSelection.batches`, which is not in line with expected standards. In any case, this commit can resolve the issue.

