### PR TITLE
New prompting strategy

### DIFF
--- a/GUI/MainWindow.py
+++ b/GUI/MainWindow.py
@@ -181,6 +181,7 @@ class MainWindow(QMainWindow):
             elif command.datamodel:
                 # Shouldn't need to do a full model rebuild often? 
                 self.datamodel = command.datamodel
+                self.action_handler.datamodel = self.datamodel
                 self.model_viewer.SetDataModel(self.datamodel)
                 self.model_viewer.show()
 

--- a/GUI/ProjectActions.py
+++ b/GUI/ProjectActions.py
@@ -39,7 +39,9 @@ class ProjectActions(QObject):
 
     def __init__(self, mainwindow : QMainWindow = None):
         super().__init__()
+        # TODO: add a proxy interface for ProjectActions to communicate with the main window
         self._mainwindow = mainwindow
+        self.datamodel = mainwindow.project.datamodel if mainwindow.project else None
         self.AddAction('Quit', self._quit, QStyle.StandardPixmap.SP_DialogCloseButton, 'Ctrl+W', 'Exit Program')
         self.AddAction('Load Subtitles', self._load_subtitle_file, QStyle.StandardPixmap.SP_DialogOpenButton)
         self.AddAction('Save Project', self._save_project_file, QStyle.StandardPixmap.SP_DialogSaveButton, 'Ctrl+S', 'Save project')
@@ -150,7 +152,8 @@ class ProjectActions(QObject):
         if not datamodel.project.subtitles.scenes:
             raise ActionError("Subtitles have not been batched")
 
-    def _start_translating(self, datamodel : ProjectDataModel):
+    def _start_translating(self):
+        datamodel : ProjectDataModel = self.datamodel
         self._validate_datamodel(datamodel)
 
         if datamodel.project.needsupdate:
@@ -159,7 +162,8 @@ class ProjectActions(QObject):
         if self._check_api_key():
             self._issue_command(ResumeTranslationCommand(multithreaded=False))
 
-    def _start_translating_fast(self, datamodel : ProjectDataModel):
+    def _start_translating_fast(self):
+        datamodel : ProjectDataModel = self.datamodel
         self._validate_datamodel(datamodel)
 
         if datamodel.project.needsupdate:

--- a/GUI/ProjectCommands.py
+++ b/GUI/ProjectCommands.py
@@ -193,7 +193,7 @@ class TranslateSceneCommand(Command):
             self.translator.StopTranslating()
     
     def _on_batch_translated(self, batch : SubtitleBatch):
-        if self.datamodel:
+        if self.datamodel and batch.translated:
             update = {
                 'summary' : batch.summary,
                 'context' : batch.context,

--- a/GUI/ProjectCommands.py
+++ b/GUI/ProjectCommands.py
@@ -178,13 +178,14 @@ class TranslateSceneCommand(Command):
             })
 
             for batch in scene.batches:
-                if not self.batch_numbers or batch.number in self.batch_numbers:
-                    self.datamodel_update[self.scene_number][batch.number] = {
-                        'summary' : batch.summary,
-                        'context' : batch.context,
-                        'errors' : batch.errors,
-                        'translated' : { line.number : { 'text' : line.text } for line in batch.translated } 
-                    }
+                if batch.translated:
+                    if not self.batch_numbers or batch.number in self.batch_numbers:
+                        self.datamodel_update[self.scene_number][batch.number] = {
+                            'summary' : batch.summary,
+                            'context' : batch.context,
+                            'errors' : batch.errors,
+                            'translated' : { line.number : { 'text' : line.text } for line in batch.translated } 
+                        }
 
         return True
     

--- a/LICENSE
+++ b/LICENSE
@@ -376,7 +376,218 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+-------------------------------------------
+regex
+-------------------------------------------
+This work was derived from the 're' module of CPython 2.6 and CPython 3.1,
+copyright (c) 1998-2001 by Secret Labs AB and licensed under CNRI's Python 1.6
+license.
 
+All additions and alterations are licensed under the Apache 2.0 License.
+
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2020 Matthew Barnett
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+   
 -------------------------------------------
 requests
 -------------------------------------------
@@ -713,5 +924,4 @@ Python is included in distributions in accordance with the PSF License Agreement
 8. By copying, installing or otherwise using Python 3.11.3, Licensee agrees
    to be bound by the terms and conditions of this License Agreement.
    
-
 

--- a/PySubtitleGPT/ChatGPTClient.py
+++ b/PySubtitleGPT/ChatGPTClient.py
@@ -5,6 +5,7 @@ import openai.error
 
 from PySubtitleGPT.ChatGPTPrompt import ChatGPTPrompt
 from PySubtitleGPT.ChatGPTTranslation import ChatGPTTranslation
+from PySubtitleGPT.Helpers import ParseDelayFromHeader
 from PySubtitleGPT.Options import Options
 from PySubtitleGPT.SubtitleError import NoTranslationError, TranslationError, TranslationImpossibleError
 
@@ -121,7 +122,7 @@ class ChatGPTClient:
             except openai.error.RateLimitError as e:
                 retry_after = e.headers.get('x-ratelimit-reset-requests') or e.headers.get('Retry-After')
                 if retry_after:
-                    retry_seconds = float(retry_after.rstrip("s"))
+                    retry_seconds = ParseDelayFromHeader(retry_after)
                     logging.warning(f"Rate limit hit, retrying in {retry_seconds} seconds...")
                     time.sleep(retry_seconds)
                     continue

--- a/PySubtitleGPT/ChatGPTPrompt.py
+++ b/PySubtitleGPT/ChatGPTPrompt.py
@@ -61,7 +61,7 @@ class ChatGPTPrompt:
         source_lines = [ line.prompt for line in lines ]
         source_text = '\n\n'.join(source_lines)
         if tag_lines:
-            return f"<context>\n{tag_lines}\n</context>\n\n{prompt}\n\n<batch>\n{source_text}\n</batch>\n"
+            return f"<context>\n{tag_lines}\n</context>\n\n{prompt}\n\n{source_text}\n\n"
         elif prompt:
             return f"{prompt}\n\n{source_text}\n"
         else:

--- a/PySubtitleGPT/ChatGPTPrompt.py
+++ b/PySubtitleGPT/ChatGPTPrompt.py
@@ -1,7 +1,8 @@
 import logging
 
-from PySubtitleGPT.Helpers import GenerateTag, GenerateTagLines, GenerateBatchPrompt
+from PySubtitleGPT.Helpers import GenerateTag, GenerateTagLines
 from PySubtitleGPT.SubtitleError import TranslationError
+from PySubtitleGPT.SubtitleLine import SubtitleLine
 
 class ChatGPTPrompt:
     def __init__(self, instructions):
@@ -18,13 +19,6 @@ class ChatGPTPrompt:
             if context_tags:
                 self.messages.append({'role': "user", 'content': context_tags})
 
-            # previous_batch = context.get('previous_batch')
-            # if previous_batch:
-            #     previous_originals = previous_batch.originals
-            #     previous_lines = [ line.prompt for line in previous_originals ]
-            #     user_previous = linesep.join(previous_lines)
-            #     self.messages.append({'role': "assistant", 'content': user_previous})
-
             summaries = context.get('summaries')
             if summaries:
                 tags = ( GenerateTag('summary', summary) for summary in summaries )
@@ -32,10 +26,10 @@ class ChatGPTPrompt:
 
             tag_lines = GenerateTagLines(context, ['scene', 'summary'])
 
-            self.user_prompt = GenerateBatchPrompt(prompt, lines, tag_lines)
+            self.user_prompt = self.GenerateBatchPrompt(prompt, lines, tag_lines)
 
         else:
-            self.user_prompt = GenerateBatchPrompt(prompt, lines)
+            self.user_prompt = self.GenerateBatchPrompt(prompt, lines)
 
         self.messages.append({'role': "user", 'content': self.user_prompt})
 
@@ -57,5 +51,20 @@ class ChatGPTPrompt:
             { 'role': "system", 'content': retry_instructions },
             { 'role': "user", 'content': retry_prompt }
         ])
+
+    def GenerateBatchPrompt(self, prompt : str, lines : list[SubtitleLine], tag_lines=None):
+        """
+        Create the user prompt for translating a set of lines
+
+        :param tag_lines: optional list of extra lines to include at the top of the prompt.
+        """
+        source_lines = [ line.prompt for line in lines ]
+        source_text = '\n\n'.join(source_lines)
+        if tag_lines:
+            return f"<context>\n{tag_lines}\n</context>\n\n{prompt}\n\n<batch>\n{source_text}\n</batch>\n"
+        elif prompt:
+            return f"{prompt}\n\n{source_text}\n"
+        else:
+            return f"\n{source_text}\n"
 
 

--- a/PySubtitleGPT/ChatGPTTranslationParser.py
+++ b/PySubtitleGPT/ChatGPTTranslationParser.py
@@ -115,13 +115,13 @@ class ChatGPTTranslationParser:
                 if translation.original:
                     if IsTextContentEqual(translation.original, item.text):
                         # A match on the original text is pretty compelling
-                        possible_matches.append(item, translation)
+                        possible_matches.append((item, translation))
                         continue
                     elif IsTextContentEqual(translation.text, item.text):
                         # GPT sometimes swaps the original and translated text - swap them back
                         translation.text = translation.original
                         translation.original = item.text
-                        possible_matches.append(item, translation)
+                        possible_matches.append((item, translation))
                         continue
 
                     #TODO: check for merged lines

--- a/PySubtitleGPT/ChatGPTTranslationParser.py
+++ b/PySubtitleGPT/ChatGPTTranslationParser.py
@@ -2,7 +2,7 @@ import logging
 import re
 
 from PySubtitleGPT.Options import Options
-from PySubtitleGPT.Helpers import MergeTranslations
+from PySubtitleGPT.Helpers import IsTextContentEqual, MergeTranslations
 from PySubtitleGPT.SubtitleLine import SubtitleLine
 from PySubtitleGPT.ChatGPTTranslation import ChatGPTTranslation
 from PySubtitleGPT.SubtitleError import LineTooLongError, NoTranslationError, TooManyNewlinesError, UnmatchedLinesError, UntranslatedLinesError
@@ -88,7 +88,7 @@ class ChatGPTTranslationParser:
                 translation.start = item.start
                 translation.end = item.end
 
-                if translation.text == item.text:
+                if IsTextContentEqual(translation.text, item.text):
                     # Check for swapped original & translation
                     translation.text = translation.original
                     translation.original = item.text
@@ -113,16 +113,18 @@ class ChatGPTTranslationParser:
         for item in unmatched:
             for translation in self.translations.values():
                 if translation.original:
-                    if translation.original == item.text:
+                    if IsTextContentEqual(translation.original, item.text):
                         # A match on the original text is pretty compelling
                         possible_matches.append(item, translation)
                         continue
-                    elif translation.text == item.text:
+                    elif IsTextContentEqual(translation.text, item.text):
                         # GPT sometimes swaps the original and translated text - swap them back
                         translation.text = translation.original
                         translation.original = item.text
                         possible_matches.append(item, translation)
                         continue
+
+                    #TODO: check for merged lines
 
                 # This is not very convincing logic but let's try it
                 if translation.start <= item.start and translation.end >= item.end:

--- a/PySubtitleGPT/ChatGPTTranslationParser.py
+++ b/PySubtitleGPT/ChatGPTTranslationParser.py
@@ -8,7 +8,7 @@ from PySubtitleGPT.ChatGPTTranslation import ChatGPTTranslation
 from PySubtitleGPT.SubtitleError import LineTooLongError, NoTranslationError, TooManyNewlinesError, UnmatchedLinesError, UntranslatedLinesError
 
 #template = re.compile(r"<translation\s+start='(?P<start>[\d:,]+)'\s+end='(?P<end>[\d:,]+)'>(?P<body>[\s\S]*?)<\/translation>", re.MULTILINE)
-template = re.compile(r"#(?P<number>\d+)[\s\r\n]+Original>[\s\r\n]+(?P<original>[\s\S]*?)[\s\r\n]Translation>[\s\r\n]+(?P<body>[\s\S]*?)(?:\n{2,})", re.MULTILINE)
+template = re.compile(r"#(?P<number>\d+)(?:[\s\r\n]+Original>[\s\r\n]+(?P<original>[\s\S]*?))?[\s\r\n]*Translation>[\s\r\n]+(?P<body>[\s\S]*?)(?:\n{2,})", re.MULTILINE)
 
 #TODO: update fallback patterns with start and end groups
 fallback_patterns = [

--- a/PySubtitleGPT/ChatGPTTranslationParser.py
+++ b/PySubtitleGPT/ChatGPTTranslationParser.py
@@ -8,10 +8,11 @@ from PySubtitleGPT.ChatGPTTranslation import ChatGPTTranslation
 from PySubtitleGPT.SubtitleError import LineTooLongError, NoTranslationError, TooManyNewlinesError, UnmatchedLinesError, UntranslatedLinesError
 
 #template = re.compile(r"<translation\s+start='(?P<start>[\d:,]+)'\s+end='(?P<end>[\d:,]+)'>(?P<body>[\s\S]*?)<\/translation>", re.MULTILINE)
-template = re.compile(r"<translation\s+start='(?P<start>[\d:,]+)'\s+end='(?P<end>[\d:,]+)'>[\s\r\n]*(?P<body>[\s\S]*?)<\/translation>", re.MULTILINE)
+template = re.compile(r"#(?P<number>\d+)[\s\r\n]+Original>[\s\r\n]+(?P<original>[\s\S]*?)[\s\r\n]Translation>[\s\r\n]+(?P<body>[\s\S]*?)(?:\n{2,})", re.MULTILINE)
 
 #TODO: update fallback patterns with start and end groups
 fallback_patterns = [
+    re.compile(r"<translation\s+start='(?P<start>[\d:,]+)'\s+end='(?P<end>[\d:,]+)'>[\s\r\n]*(?P<body>[\s\S]*?)<\/translation>", re.MULTILINE),
     re.compile(r"<translation\s+number='(?P<number>.+?)'\s+start='(?P<start>[\d:,]+)'\s+end='(?P<end>[\d:,]+)'>\s*(?P<body>.*?)\s*<\/translation>", re.MULTILINE),
     re.compile(r'<translation\s*line=(\d+)\s*>(?:")?(.*?)(?:")?\s*(?:" /)?</translation>', re.MULTILINE),
     re.compile(r'<original\s*line=(\d+)\s*>(?:")?(.*?)(?:")?\s*(?:" /)?</original>', re.MULTILINE),
@@ -43,7 +44,7 @@ class ChatGPTTranslationParser:
         if not self.text:
             raise ValueError("No translated text provided")
 
-        matches = self.FindMatches(self.text)
+        matches = self.FindMatches(f"{self.text}\n\n")
 
         logging.debug(f"Matches: {str(matches)}")
 
@@ -64,13 +65,14 @@ class ChatGPTTranslationParser:
         re.findall has some very unhelpful behaviour, so we use finditer instead.
         """
         return [{ 
+            'body': match.group('body'),
             'number': match.groupdict().get('number'),
-            'start': match.group('start'), 
-            'end': match.group('end'), 
-            'body': match.group('body')
+            'start': match.groupdict().get('start'), 
+            'end': match.groupdict().get('end'), 
+            'original': match.groupdict().get('original')
             } for match in template.finditer(text)]
 
-    def MatchTranslations(self, originals):
+    def MatchTranslations(self, originals : list[SubtitleLine]):
         """
         Match lines in the translation with the original subtitles
         """
@@ -83,6 +85,8 @@ class ChatGPTTranslationParser:
             translation = self.translations.get(item.key)
             if translation:
                 translation.number = item.number
+                translation.start = item.start
+                translation.end = item.end
                 item.translation = translation.text
             else:
                 item.translation = None
@@ -95,13 +99,18 @@ class ChatGPTTranslationParser:
 
         return self.translated, unmatched
 
-    def TryFuzzyMatches(self, unmatched):
+    def TryFuzzyMatches(self, unmatched : list [SubtitleLine]):
         """
         Try to match translations to their source lines using heuristics
         """
-        possible_matches = []
+        possible_matches : list[(SubtitleLine,SubtitleLine)] = []
         for item in unmatched:
             for translation in self.translations.values():
+                # A match on the original text is pretty compelling
+                if translation.original and translation.original == item.text:
+                    possible_matches.append(item, translation)
+                    continue
+
                 # This is not very convincing logic but let's try it
                 if translation.start <= item.start and translation.end >= item.end:
                     possible_matches.append((item, translation))

--- a/PySubtitleGPT/Helpers.py
+++ b/PySubtitleGPT/Helpers.py
@@ -274,3 +274,31 @@ def PerformSubstitutions(substitutions, input):
         
     return result
 
+
+def ParseDelayFromHeader(value : str):
+    """
+    Try to figure out how long a suggested retry-after is
+    """
+    if not isinstance(value, str):
+        return 12.3
+
+    match = re.match(r"([0-9\.]+)(\w+)?", value)
+    if not match:
+        return 32.1
+
+    try:
+        delay, unit = match.groups()
+        delay = float(delay)
+        unit = unit.lower() if unit else 's'
+        if unit == 's':
+            pass
+        elif unit == 'm':
+            delay *= 60
+        elif unit == 'ms':
+            delay /= 1000
+
+        return max(1, delay)  # ensure at least 1 second
+
+    except Exception as e:
+        logging.error(f"Unexpected time value '{value}'")
+        return 6.66

--- a/PySubtitleGPT/SubtitleLine.py
+++ b/PySubtitleGPT/SubtitleLine.py
@@ -74,8 +74,7 @@ class SubtitleLine:
         return '\n'.join([
             f"#{self.number}",
             f"Original>",
-            self.text_normalized,
-            "#"
+            self.text_normalized
         ])
 
     @property

--- a/PySubtitleGPT/SubtitleLine.py
+++ b/PySubtitleGPT/SubtitleLine.py
@@ -18,7 +18,7 @@ class SubtitleLine:
         return self.item.to_srt() if self.item else None
 
     def __repr__(self):
-        return f"Line({srt.timedelta_to_srt_timestamp(self.start) if self.start else '***'}, {repr(self.text)})"
+        return f"Line({srt.timedelta_to_srt_timestamp(self.start) if self.start else self.number}, {repr(self.text)})"
 
     @property
     def key(self):
@@ -83,11 +83,12 @@ class SubtitleLine:
 
     @classmethod
     def Construct(cls, number, start, end, text, original = None):
+        number = int(number) if number else None
         start = GetTimeDelta(start)
         end = GetTimeDelta(end)
         text = srt.make_legal_content(text) if text else None
         original = srt.make_legal_content(original) if original else None
-        item = srt.Subtitle(int(number), start, end, text)
+        item = srt.Subtitle(number, start, end, text)
         return SubtitleLine(item, original=original) 
     
     @classmethod

--- a/PySubtitleGPT/SubtitleLine.py
+++ b/PySubtitleGPT/SubtitleLine.py
@@ -58,7 +58,7 @@ class SubtitleLine:
 
     @property
     def line(self):
-        return self._item.to_srt() if self._item else None
+        return self._item.to_srt() if self._item and self._item.content else None
 
     @property
     def translated(self):

--- a/PySubtitleGPT/SubtitleLine.py
+++ b/PySubtitleGPT/SubtitleLine.py
@@ -9,9 +9,10 @@ class SubtitleLine:
     Represents a single line, with a number and start and end times plus original text 
     and (optionally) an associated translation.
     """
-    def __init__(self, line, translation=None):
+    def __init__(self, line, translation=None, original=None):
         self.item = line or srt.Subtitle()
         self.translation = translation
+        self.original = original
     
     def __str__(self):
         return self.item.to_srt() if self.item else None
@@ -21,15 +22,19 @@ class SubtitleLine:
 
     @property
     def key(self):
-        return str(self.start) if self.start else self.number
+        return self.number if self.number else str(self.start)
 
     @property
-    def number(self):
+    def number(self) -> int:
         return self._item.index if self._item else None
 
     @property
-    def text(self):
+    def text(self) -> str:
         return self._item.content if self._item else None
+    
+    @property
+    def text_normalized(self) -> str:
+        return self.text.replace(linesep, '\n') if self.text else None
 
     @property
     def start(self) -> timedelta:
@@ -37,7 +42,7 @@ class SubtitleLine:
     
     @property
     def srt_start(self) -> str:
-        return srt.timedelta_to_srt_timestamp(self._item.start) if self._item else None
+        return srt.timedelta_to_srt_timestamp(self.start) if self.start else None
     
     @property
     def end(self) -> timedelta:
@@ -45,7 +50,7 @@ class SubtitleLine:
     
     @property
     def srt_end(self) -> str:
-        return srt.timedelta_to_srt_timestamp(self._item.end) if self._item else None
+        return srt.timedelta_to_srt_timestamp(self.end) if self.end else None
     
     @property
     def duration(self) -> timedelta:
@@ -67,9 +72,10 @@ class SubtitleLine:
             return None
         
         return '\n'.join([
-            f"<original start='{self.srt_start}' end='{self.srt_end}'>",
-            self.text.replace(linesep, '\n'),
-            f"</original>"
+            f"#{self.number}",
+            f"Original>",
+            self.text_normalized,
+            "#"
         ])
 
     @property
@@ -77,11 +83,12 @@ class SubtitleLine:
         return self._item
 
     @classmethod
-    def Construct(cls, number, start, end, text):
+    def Construct(cls, number, start, end, text, original = None):
         start = GetTimeDelta(start)
         end = GetTimeDelta(end)
-        text = srt.make_legal_content(text)
-        item = srt.Subtitle(number, start, end, text)
+        text = srt.make_legal_content(text) if text else None
+        original = srt.make_legal_content(original) if original else None
+        item = srt.Subtitle(int(number), start, end, text, original)
         return SubtitleLine(item) 
     
     @classmethod
@@ -91,9 +98,9 @@ class SubtitleLine:
         """
         return SubtitleLine.Construct(
             values.get('number') or values.get('index'), 
-            values['start'].strip(), 
-            values['end'].strip(), 
-            values['body'].strip())
+            values.get('start'), 
+            values.get('end'), 
+            values.get('body'))
 
     @classmethod
     def FromMatch(cls, match):

--- a/PySubtitleGPT/SubtitleLine.py
+++ b/PySubtitleGPT/SubtitleLine.py
@@ -88,8 +88,8 @@ class SubtitleLine:
         end = GetTimeDelta(end)
         text = srt.make_legal_content(text) if text else None
         original = srt.make_legal_content(original) if original else None
-        item = srt.Subtitle(int(number), start, end, text, original)
-        return SubtitleLine(item) 
+        item = srt.Subtitle(int(number), start, end, text)
+        return SubtitleLine(item, original=original) 
     
     @classmethod
     def FromDictionary(cls, values):
@@ -100,7 +100,8 @@ class SubtitleLine:
             values.get('number') or values.get('index'), 
             values.get('start'), 
             values.get('end'), 
-            values.get('body'))
+            values.get('body'),
+            values.get('original'))
 
     @classmethod
     def FromMatch(cls, match):

--- a/PySubtitleGPT/SubtitleTranslator.py
+++ b/PySubtitleGPT/SubtitleTranslator.py
@@ -139,7 +139,8 @@ class SubtitleTranslator:
                 context['scene'] = scene.summary
 
             self.TranslateBatches(batches, context, remaining_lines)
-            scene.summary = context['summary'] or scene.summary
+
+            scene.summary = scene.summary or context['summary']
 
             # Notify observers the scene was translated
             self.events.scene_translated(scene)

--- a/instructions.txt
+++ b/instructions.txt
@@ -1,24 +1,39 @@
-Your task is to accurately translate subtitles into a target language. The user will provide lines in the following format:
+Your task is to accurately translate subtitles into a target language. The user will provide lines for translation in this format:
 
-<original start='01:02:33,400' end='01:02:36,700'>
-Dialogue to be translated
-</original>
+#n
+Original>
+dialogue to be translated
 
-You should respond with a matching line in the target language for each original line, in the following format:
+For each line of dialogue, you should provide an accurate, concise, and natural-sounding translation. The format for your responses should be like this:
 
-<translation start='01:02:33,400' end='01:02:36,700'>
-Translated dialogue
-</translation>
+#10
+Original>
+你們喜歡忍者嗎
+Translation>
+Do you like ninjas?
 
-Do not merge multiple lines into a single line in the translation as this can lead to confusion and inaccuracies.
+#100
+Original>
+在今後的社會
+Translation>
+In the future society,
 
-Your translations should be concise and accurate, whilst sounding natural; do not improvise. Be careful to preserve start and end times. 
+#101
+Original>
+只有念好書 長大才能出人頭地
+Translation>
+only by studying hard
+can one succeed in life.
 
-If the user provides a synopsis of the film or a list of characters, use them to guide your translation.
+Please ensure that each line of dialogue remains distinct in the translation. Merging lines together can lead to confusion and potential mistiming during playback.
 
-Include a one or two line <summary/> of recent events at the end of each reply.
+The user may provide additional context, such as a synopsis of the film or a summary of the current scene. Use this to improve the accuracy of your translations.
+
+At the end of each set of translations, include a one or two line summary of the events encapsulated by a <summary/> tag. This should reflect the meaning of the dialog in the context of the scene.
 
 #######################
 There was an issue with the previous translation. 
 
-Please translate the subtitles again, paying careful attention to ensure that each line is translated separately, and that start and end times match the original dialogue. Do not merge lines, it can lead to incorrect timing and confusion.
+Please translate the subtitles again, paying careful attention to ensure that each line is translated separately, and that every line has a matching translation.
+
+Do not merge lines together in the translation, it leads to incorrect timings and confusion for the reader.

--- a/readme.md
+++ b/readme.md
@@ -181,6 +181,7 @@ This project uses several useful libraries:
 - openai, of course (https://platform.openai.com/docs/libraries/python-bindings)
 - srt (https://github.com/cdown/srt)
 - requests (https://github.com/psf/requests)
+- regex (https://github.com/mrabarnett/mrab-regex)
 
 For the GUI:
 - pyside6 (https://wiki.qt.io/Qt_for_Python)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 python-dotenv
 openai
 srt
+regex
 events
 pyside6
 darkdetect


### PR DESCRIPTION
Actually an old prompting strategy but with new measures to make it work. 

We specify a format for the response which includes both original and translated lines, which makes it much harder for Chat GPT to go off-course and merge multiple lines together. We also provide clearer instructions with multiple examples of the required format.

This seems to solve the issue of merged lines and desync, but it does have a penalty in the "naturalness" of translations. There are times when subtitles are split across multiple lines and a direct translation of each would not be grammatically valid in the target language, which is why it used to merge them. Instead, it will now typically over-translate, making each fragment "complete", which usually means too long and repetitive.

This is easier to fix by hand than desyncs though, so overall it seems like an improvement. The ideal approach is clearly to allow Chat GPT to merge lines where it improves the translation, but require that it reports which lines have been merged so that we can fix up the timing. It needs a bit more brain power than I can spare right now though! 

It's possible just telling it that its response will be processed by an automated system will be enough to keep it focused!