### PR TITLE
Change the default value of movie_name

### DIFF
--- a/gpt-subtrans.py
+++ b/gpt-subtrans.py
@@ -40,7 +40,7 @@ try:
         'max_lines': args.maxlines,
         'rate_limit': args.ratelimit,
         'target_language': args.target_language,
-        'movie_name': args.moviename or args.input,
+        'movie_name': args.moviename or os.path.splitext(os.path.basename(args.input))[0],
         'synopsis': args.synopsis,
         'characters': ParseCharacters(args.characters or args.character),
         'substitutions': ParseSubstitutions(args.substitution),


### PR DESCRIPTION
Using the filename without path and extension as the default value for `movie_name` allows for more accurate translations.
If the path is too long, or if there are irregular characters, the translation quality may be affected.