### PR TITLE
Support third-party API base address

### DIFF
--- a/GUI/NewProjectSettings.py
+++ b/GUI/NewProjectSettings.py
@@ -28,9 +28,10 @@ class NewProjectSettings(QDialog):
         self.project : SubtitleProject = project
         self.settings : dict = project.options.GetSettings()
         api_key = project.options.api_key()
+        api_base = project.options.api_base()
 
         if api_key:
-            models = SubtitleTranslator.GetAvailableModels(api_key)
+            models = SubtitleTranslator.GetAvailableModels(api_key, api_base)
             self.SETTINGS['gpt_model'] = (models, self.SETTINGS['gpt_model'][1])
 
         instruction_files = GetInstructionFiles()

--- a/GUI/SettingsDialog.py
+++ b/GUI/SettingsDialog.py
@@ -15,6 +15,7 @@ class SettingsDialog(QDialog):
         },
         'GPT': {
             'api_key': str,
+            'api_base': str,
             'gpt_model': str,
             'temperature': float,
             'rate_limit': float

--- a/GUI/TranslatorOptions.py
+++ b/GUI/TranslatorOptions.py
@@ -26,7 +26,7 @@ class TranslatorOptionsDialog(QDialog):
         self.setMinimumWidth(800)
 
         self.data = data
-        self.models = SubtitleTranslator.GetAvailableModels(data.get('api_key'))
+        self.models = SubtitleTranslator.GetAvailableModels(data.get('api_key'), data.get('api_base'))
 
         self.form_layout = QFormLayout()
         self.model_edit = self._add_form_option("model", self.data.get('gpt_model', ''), self.models, tooltip="Model to use for translation")

--- a/PySubtitleGPT/Options.py
+++ b/PySubtitleGPT/Options.py
@@ -31,6 +31,7 @@ def env_bool(key, default=False):
 default_options = {
     'version': __version__,
     'api_key': os.getenv('API_KEY', None),
+    'api_base': os.getenv('API_BASE', 'https://api.openai.com/v1'),
     'gpt_model': os.getenv('GPT_MODEL', 'gpt-3.5-turbo'),
     'gpt_prompt': os.getenv('GPT_PROMPT', "Please translate these subtitles[ for movie][ to language]."),
     'instruction_file': os.getenv('INSTRUCTION_FILE', "instructions.txt"),
@@ -105,6 +106,9 @@ class Options:
 
     def api_key(self):
         return self.get('api_key')
+
+    def api_base(self):
+        return self.get('api_base')    
     
     def allow_multithreaded_translation(self):
         return self.get('max_threads') and self.get('max_threads') > 1

--- a/PySubtitleGPT/SubtitleTranslator.py
+++ b/PySubtitleGPT/SubtitleTranslator.py
@@ -32,7 +32,10 @@ class SubtitleTranslator:
         if not openai.api_key:
             raise ValueError('API key must be set in .env or provided as an argument')
         
-        logging.debug(f"Using API Key: {openai.api_key}")
+        if options.api_base():
+            openai.api_base = options.api_base()
+        
+        logging.debug(f"Using API Key: {openai.api_key}, Using API Base: {openai.api_base}")
 
         self.subtitles = subtitles
         self.options = options
@@ -51,11 +54,14 @@ class SubtitleTranslator:
         logging.debug(f"Translation context:\n{linesep.join(context_values)}")
 
     @classmethod
-    def GetAvailableModels(cls, api_key : str):
+    def GetAvailableModels(cls, api_key : str, api_base : str):
         """
         Returns a list of possible values for the LLM model 
         """
-        response = openai.Model.list(api_key) if api_key else None
+        if api_base:
+            response = openai.Model.list(api_key, api_base = api_base) if api_key else None
+        else:
+            response = openai.Model.list(api_key) if api_key else None 
         if not response or not response.data:
             return []
 

--- a/gpt-subtrans.py
+++ b/gpt-subtrans.py
@@ -23,6 +23,7 @@ parser.add_argument('-c', '--character', action='append', type=str, default=None
 parser.add_argument('-s', '--substitution', action='append', type=str, default=None, help="A pair of strings separated by ::, to subsitute in source or translation")
 parser.add_argument('-i', '--instruction', action='append', type=str, default=None, help="An instruction for Chat GPT about the translation")
 parser.add_argument('-f', '--instructionfile', type=str, default=None, help="Name/path of a file to load GPT instructions from")
+parser.add_argument('-b', '--apibase', type=str, default=None, help="API backend base address, the default value is https://api.openai.com/v1")
 parser.add_argument('--description', type=str, default=None, help="A brief description of the film to give context")
 parser.add_argument('--characters', type=str, default=None, help="A list of character names")
 parser.add_argument('--minbatchsize', type=int, default=None, help="Minimum number of lines to consider starting a new batch")
@@ -37,6 +38,7 @@ args = parser.parse_args()
 try:
     options = Options({
         'api_key': args.apikey,
+        'api_base': args.apibase,
         'max_lines': args.maxlines,
         'rate_limit': args.ratelimit,
         'target_language': args.target_language,

--- a/readme.md
+++ b/readme.md
@@ -117,6 +117,9 @@ along with some other configuration options. See Options.py for the full list. A
 - `-k`, `--apikey`:
   Your OpenAI API Key (https://platform.openai.com/account/api-keys). Not required if it is set in .env
 
+- `-b`, `--apibase`:
+  API base address. Used for third-party API, if it is not set, it will be the default openai official API base address.
+
 - `-t`, `--temperature`:
   A higher temperature increases the random variance of translations. Default 0.
 


### PR DESCRIPTION
If not set, it defaults to the official address of openai Usage:
For command line, eg:  -b api.xxxx.com/v1
For GUI, set in the settings page

Tested with two different third-party API base addresses (both command line and GUI)