### PR TITLE
Fix crash on first run

### DIFF
--- a/GUI/FirstRunOptions.py
+++ b/GUI/FirstRunOptions.py
@@ -43,7 +43,9 @@ class FirstRunOptions(QDialog):
 
         self.model = self._create_input("Model", QLineEdit, "Default Model", self.data.get('gpt_model', ''))
 
-        self.free_plan = self._create_input("OpenAI Free Plan", QCheckBox, default_value = 'rate_limit' in self.data and self.data.get('rate_limit') > 0.0)
+        self.free_plan = self._create_input("OpenAI Free Plan", QCheckBox,
+                                            default_value=self.data.get('rate_limit') is not None and self.data.get(
+                                                'rate_limit') > 0.0)
 
         self.max_threads = self._create_input("Max Threads", QSpinBox, default_value=self.data.get('max_threads', 1))
         self.max_threads.setRange(1, 16)


### PR DESCRIPTION
Fix crash on first run `gui-subtrans.exe`.
```
Traceback (most recent call last):
  File "gui-subtrans.py", line 67, in <module>
  File "GUI\MainWindow.py", line 108, in __init__
  File "GUI\MainWindow.py", line 233, in _first_run
  File "GUI\FirstRunOptions.py", line 46, in __init__
TypeError: '>' not supported between instances of 'NoneType' and 'float'
[7228] Failed to execute script 'gui-subtrans' due to unhandled exception!
```