### PR TITLE
Add OpenAI API base URL option to installation script

### DIFF
--- a/install.bat
+++ b/install.bat
@@ -29,6 +29,14 @@ if not "!api_key!"=="" (
     echo API key saved to .env
 )
 
+echo Please enter your OpenAI API host(Leave blank for default: https://api.openai.com/v1):
+set /p api_base=API_BASE:
+
+if not "!api_base!"=="" (
+    echo API_BASE=!api_base! >> .env
+    echo API base saved to .env
+)
+
 echo Are you on the free plan? (Y/N)
 set /p free_plan=Free plan?:
 

--- a/install.sh
+++ b/install.sh
@@ -27,6 +27,13 @@ if [ ! -f ".env" ]; then
     echo "API key saved to .env"
 fi
 
+echo "Please enter your OpenAI API host(Leave blank for default: https://api.openai.com/v1):"
+read -r api_base
+if [ ! -z "$api_base" ]; then
+    echo "API_BASE=$api_base" >> .env
+    echo "API base saved to .env"
+fi
+
 echo "Are you on the free plan? (Y/N)"
 read -r free_plan
 


### PR DESCRIPTION
This commit adds a new option to the installation script: setting the OpenAI API base URL. Users can now enter a custom API base URL or leave it blank to use the default URL (https://api.openai.com/v1). This change provides more flexibility for users who need to use a different API base URL.