### PR TITLE
Project option separation

### DIFF
--- a/GUI/FileCommands.py
+++ b/GUI/FileCommands.py
@@ -33,7 +33,7 @@ class LoadSubtitleFile(Command):
                 return False
             
             self.project = project
-            self.datamodel = ProjectDataModel(project)
+            self.datamodel = ProjectDataModel(project, options)
 
             if self.datamodel.IsProjectInitialised():
                 self.datamodel.CreateViewModel()

--- a/GUI/FileCommands.py
+++ b/GUI/FileCommands.py
@@ -7,10 +7,11 @@ from PySubtitleGPT.Options import Options
 from PySubtitleGPT.SubtitleProject import SubtitleProject
 
 class LoadSubtitleFile(Command):
-    def __init__(self, filepath):
+    def __init__(self, filepath, options : Options):
         super().__init__()
         self.filepath = filepath
         self.project : SubtitleProject = None
+        self.options : Options = options
 
     def execute(self):
         logging.debug(f"Executing LoadSubtitleFile {self.filepath}")
@@ -19,7 +20,7 @@ class LoadSubtitleFile(Command):
             return False
 
         try:
-            options = self.datamodel.options if self.datamodel else None
+            options = self.options
             if not options:
                 options = Options()
                 options.Load()
@@ -34,7 +35,7 @@ class LoadSubtitleFile(Command):
             self.project = project
             self.datamodel = ProjectDataModel(project)
 
-            if project.subtitles.scenes:
+            if self.datamodel.IsProjectInitialised():
                 self.datamodel.CreateViewModel()
 
             return True

--- a/GUI/MainToolbar.py
+++ b/GUI/MainToolbar.py
@@ -3,6 +3,7 @@ from GUI.CommandQueue import CommandQueue
 
 from GUI.ProjectActions import ProjectActions
 from GUI.ProjectCommands import ResumeTranslationCommand, TranslateSceneCommand, TranslateSceneMultithreadedCommand
+from GUI.ProjectDataModel import ProjectDataModel
 from PySubtitleGPT.SubtitleProject import SubtitleProject
 
 class MainToolbar(QToolBar):
@@ -32,8 +33,8 @@ class MainToolbar(QToolBar):
             if action.text() in action_list:
                 action.setEnabled(False) 
 
-    def SetBusyStatus(self, project : SubtitleProject, command_queue : CommandQueue):
-        if not project or not project.subtitles:
+    def SetBusyStatus(self, datamodel : ProjectDataModel, command_queue : CommandQueue):
+        if not datamodel or not datamodel.IsProjectInitialised():
             self.DisableActions([ "Save Project", "Start Translating", "Start Translating Fast", "Stop Translating" ])
             self.EnableActions([ "Load Subtitles" ])
             return

--- a/GUI/MainWindow.py
+++ b/GUI/MainWindow.py
@@ -110,7 +110,7 @@ class MainWindow(QMainWindow):
             self._first_run(options)
         elif filepath:
             # Load file if we were opened with one
-            self.QueueCommand(LoadSubtitleFile(filepath), self.options)
+            self.QueueCommand(LoadSubtitleFile(filepath))
 
         logging.info(f"GPT-Subtrans {__version__}")
 

--- a/GUI/ProjectCommands.py
+++ b/GUI/ProjectCommands.py
@@ -32,8 +32,6 @@ class BatchSubtitlesCommand(Command):
         project.WriteProjectFile()
 
         self.datamodel : ProjectDataModel = self.datamodel or ProjectDataModel(project)
-        self.datamodel.project = project
-        self.datamodel.options = Options(project.options)
         self.datamodel.CreateViewModel()
         return True
         
@@ -292,8 +290,9 @@ class TranslateSceneCommand(Command):
             raise TranslationError("Unable to translate scene because project is not set on datamodel")
 
         project : SubtitleProject = self.datamodel.project
+        options = self.datamodel.options
 
-        self.translator = SubtitleTranslator(project.subtitles, project.options)
+        self.translator = SubtitleTranslator(project.subtitles, options)
 
         self.translator.events.batch_translated += self._on_batch_translated
 

--- a/GUI/ProjectDataModel.py
+++ b/GUI/ProjectDataModel.py
@@ -15,6 +15,30 @@ class ProjectDataModel:
         if project and project.options:
               self.options.update(project.options)
 
+    def UpdateOptions(self, options : Options):
+        """ Update any options that have changed """
+        self.options.update(options)
+
+        #TODO: only store options in project that are non-default
+        self.project.UpdateProjectOptions(options)
+        self.options.update(self.project.options)
+
+    def IsProjectInitialised(self):
+        """Check whether the project has been initialised (subtitles loaded and batched)"""
+        return self.project and self.project.subtitles and self.project.subtitles.scenes
+    
+    def NeedsSave(self):
+        """Does the project have changes that should be saved"""
+        return self.IsProjectInitialised() and self.project.needsupdate
+
+    def NeedsAutosave(self):
+        """Does the project have changes that should be auto-saved"""
+        return self.NeedsSave() and self.options.get('autosave')
+    
+    def SaveProject(self):
+        if self.NeedsSave():
+            self.project.WriteProjectFile()
+
     def GetLock(self):
         return QMutexLocker(self.mutex)
 

--- a/PySubtitleGPT/Options.py
+++ b/PySubtitleGPT/Options.py
@@ -177,14 +177,15 @@ class Options:
             return False
 
     def InitialiseInstructions(self):
-        instructions = self.get('instructions')
-        retry_instructions = self.get('retry_instructions')
+        instructions = self.get('instructions') or default_instructions
+        retry_instructions = self.get('retry_instructions') or default_retry_instructions
 
         # If instructions file exists load the instructions from that
         if self.get('instruction_file'):
-            instructions, retry_instructions = LoadInstructionsFile(self.get('instruction_file'))
-            instructions = instructions if instructions else default_instructions
-            retry_instructions = retry_instructions if retry_instructions else default_retry_instructions
+            file_instructions, file_retry_instructions = LoadInstructionsFile(self.get('instruction_file'))
+            if file_instructions and file_retry_instructions:
+                instructions = file_instructions
+                retry_instructions = file_retry_instructions
 
         # Add any additional instructions from the command line
         if self.get('instruction_args'):

--- a/PySubtitleGPT/SubtitleFile.py
+++ b/PySubtitleGPT/SubtitleFile.py
@@ -210,10 +210,6 @@ class SubtitleFile:
             'description': "",
             'characters': None,
             'substitutions': None,
-            'min_batch_size' : None,
-            'max_batch_size' : None,
-            'batch_threshold' : None,
-            'scene_threshold' : None,
             'match_partial_words': False,
             'include_original': False,
             'instructions_edited': False


### PR DESCRIPTION
Try to make sure custom project settings are preserved and respected, whilst global settings are updated when appropriate and applied to new projects.

A more complete separation would be better still, i.e. not using the same class for both.