### PR TITLE
Add `setuptools` to requirements.txt for gui-subtrans

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,5 @@ events
 pyside6
 darkdetect
 appdirs
+setuptools
 


### PR DESCRIPTION
Hi,

With Python 3.12.0 on Windows 11 attempting to run `main@27bc579b2537f52ea672690c2a3e4ed5c73dc5ac` inside a clean venv, I get an error. Manually installing `setuptools` fixes it:

```
C:\Users\fp\gpt-subtrans>gui-subtrans.cmd
Traceback (most recent call last):
  File "C:\Users\fp\gpt-subtrans\gui-subtrans.py", line 9, in <module>
    from GUI.MainWindow import MainWindow
  File "C:\Users\fp\gpt-subtrans\GUI\MainWindow.py", line 16, in <module>
    from GUI.AboutDialog import AboutDialog
  File "C:\Users\fp\gpt-subtrans\GUI\AboutDialog.py", line 2, in <module>
    import pkg_resources
ModuleNotFoundError: No module named 'pkg_resources'

(envsubtrans) C:\Users\fp\gpt-subtrans>pip install --upgrade setuptools
Collecting setuptools
  Obtaining dependency information for setuptools from https://files.pythonhosted.org/packages/bb/26/7945080113158354380a12ce26873dd6c1ebd88d47f5bc24e2c5bb38c16a/setuptools-68.2.2-py3-none-any.whl.metadata
  Using cached setuptools-68.2.2-py3-none-any.whl.metadata (6.3 kB)
Using cached setuptools-68.2.2-py3-none-any.whl (807 kB)
Installing collected packages: setuptools
Successfully installed setuptools-68.2.2

[notice] A new release of pip is available: 23.2.1 -> 23.3.1
[notice] To update, run: python.exe -m pip install --upgrade pip

(envsubtrans) C:\Users\fp\gpt-subtrans>gui-subtrans.cmd
INFO: Loaded settings from C:\Users\fp\AppData\Roaming\MachineWrapped\GPTSubtrans\settings.json
INFO: Loading stylesheet from C:\Users\fp\gpt-subtrans\theme\subtrans-dark.qss
INFO: GPT-Subtrans v0.4.4
```

(With Python 3.12, I did have to run `pip install aiohttp==3.9.0b0` before continuing to install the packages from the requirements file - but that's something out this project's control)

Thank you very much for this program.