### PR TITLE
Support for local LLM servers

### DIFF
--- a/GUI/AboutDialog.py
+++ b/GUI/AboutDialog.py
@@ -67,7 +67,7 @@ class AboutDialog(QDialog):
         license_text.setWordWrap(True)
         
         # Libraries and their versions
-        libraries = ["srt", "pyside6", "openai", "google-generativeai", "regex", "events", "darkdetect", "appdirs", "python-dotenv"]
+        libraries = ["srt", "pyside6", "openai", "google-generativeai", "anthropic", "regex", "events", "httpx", "requests", "darkdetect", "appdirs", "python-dotenv"]
         library_strings = []
 
         for lib in libraries:

--- a/GUI/EditInstructionsDialog.py
+++ b/GUI/EditInstructionsDialog.py
@@ -11,9 +11,9 @@ from PySide6.QtWidgets import (
     QSizePolicy
     )
 from GUI.GuiHelpers import GetResourcePath
-from GUI.Widgets.OptionsWidgets import MULTILINE_OPTION, CreateOptionWidget
+from GUI.Widgets.OptionsWidgets import CreateOptionWidget
 
-from PySubtitle.Options import Options
+from PySubtitle.Options import MULTILINE_OPTION, Options
 from PySubtitle.Instructions import Instructions
 
 class EditInstructionsDialog(QDialog):

--- a/GUI/MainWindow.py
+++ b/GUI/MainWindow.py
@@ -151,9 +151,6 @@ class MainWindow(QMainWindow):
         if result == QDialog.Accepted:
             self._update_settings(dialog.settings)
 
-            if not self.datamodel.ValidateProviderSettings():
-                logging.warning("Translation provider settings are not valid. Please check the settings.")
-
     def _first_run(self, options: Options):
         if not options.available_providers:
             logging.error("No translation providers available. Please install one or more providers.")
@@ -199,6 +196,9 @@ class MainWindow(QMainWindow):
 
         # Update the project and provider settings
         self.datamodel.UpdateSettings(updated_settings)
+
+        if not self.datamodel.ValidateProviderSettings():
+            logging.warning("Translation provider settings are not valid. Please check the settings.")
 
         if 'theme' in updated_settings:
             LoadStylesheet(self.global_options.theme)

--- a/GUI/Widgets/Editors.py
+++ b/GUI/Widgets/Editors.py
@@ -3,7 +3,8 @@ from PySide6.QtWidgets import (QDialog, QFormLayout, QVBoxLayout, QLabel, QDialo
 from GUI.ViewModel.BatchItem import BatchItem
 from GUI.ViewModel.LineItem import LineItem
 from GUI.ViewModel.SceneItem import SceneItem
-from GUI.Widgets.OptionsWidgets import MULTILINE_OPTION, CreateOptionWidget
+from GUI.Widgets.OptionsWidgets import CreateOptionWidget
+from PySubtitle.Options import MULTILINE_OPTION
 
 class EditDialog(QDialog):
     def __init__(self, model, parent=None, title=None) -> None:

--- a/GUI/Widgets/OptionsWidgets.py
+++ b/GUI/Widgets/OptionsWidgets.py
@@ -5,7 +5,7 @@ from PySide6.QtCore import Signal
 from PySide6.QtWidgets import (QWidget, QLineEdit, QSpinBox, QDoubleSpinBox, QComboBox, QCheckBox, QTextEdit, QSizePolicy, QHBoxLayout, QVBoxLayout)
 from PySide6.QtGui import QTextOption
 
-MULTILINE_OPTION = 'multiline'
+from PySubtitle.Options import MULTILINE_OPTION
 
 class OptionWidget(QWidget):
     contentChanged = Signal()

--- a/LICENSE
+++ b/LICENSE
@@ -766,6 +766,21 @@ requests
       incurred by, or claims asserted against, such Contributor by reason
       of your accepting any such warranty or additional liability.
 
+
+-------------------------------------------
+httpx
+-------------------------------------------
+
+MIT License
+
+Copyright (c) 2021 ProjectDiscovery, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
 -------------------------------------------
 Google Generative AI
 -------------------------------------------

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
--------------------------------------------
+==========================
 GPT-Subtrans License
--------------------------------------------
+==========================
 
 MIT License
 
@@ -25,9 +25,9 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
--------------------------------------------
+==========================
 OpenAI
--------------------------------------------
+==========================
 
 The MIT License
 
@@ -52,9 +52,9 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 
--------------------------------------------
+==========================
 srt
--------------------------------------------
+==========================
 
 The MIT License
 
@@ -79,9 +79,9 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 
--------------------------------------------
+==========================
 PySide6
--------------------------------------------
+==========================
 
                    GNU LESSER GENERAL PUBLIC LICENSE
                        Version 3, 29 June 2007
@@ -249,9 +249,9 @@ apply, that proxy's public statement of acceptance of any version is
 permanent authorization for you to choose that version for the
 Library.
 
--------------------------------------------
+==========================
 python-dotenv
--------------------------------------------
+==========================
 
 Copyright (c) 2014, Saurabh Kumar (python-dotenv), 2013, Ted Tieken (django-dotenv-rw), 2013, Jacob Kaplan-Moss (django-dotenv)
 
@@ -281,9 +281,9 @@ LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
 NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-------------------------------------------------------------------------
+==========================-----------------------------
 appdirs 
-----------------------------------------------------------------------------
+==========================---------------------------------
 
 The MIT License (MIT)
 
@@ -308,9 +308,9 @@ CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
 TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
--------------------------------------------
+==========================
 events
--------------------------------------------
+==========================
 
 Copyright (c) 2017 by Nicola Iarocci and contributors.  See AUTHORS
 for more details.
@@ -347,9 +347,9 @@ SOFTWARE AND DOCUMENTATION, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
 DAMAGE.
 
 
--------------------------------------------
+==========================
 darkdetect
--------------------------------------------
+==========================
 
 Copyright (c) 2019, Alberto Sottile
 All rights reserved.
@@ -376,9 +376,9 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
--------------------------------------------
+==========================
 regex
--------------------------------------------
+==========================
 This work was derived from the 're' module of CPython 2.6 and CPython 3.1,
 copyright (c) 1998-2001 by Secret Labs AB and licensed under CNRI's Python 1.6
 license.
@@ -588,9 +588,9 @@ All additions and alterations are licensed under the Apache 2.0 License.
    See the License for the specific language governing permissions and
    limitations under the License.
    
--------------------------------------------
+==========================
 requests
--------------------------------------------
+==========================
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/
@@ -767,9 +767,9 @@ requests
       of your accepting any such warranty or additional liability.
 
 
--------------------------------------------
+==========================
 httpx
--------------------------------------------
+==========================
 
 MIT License
 
@@ -781,9 +781,9 @@ The above copyright notice and this permission notice shall be included in all c
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
--------------------------------------------
+==========================
 Google Generative AI
--------------------------------------------
+==========================
 
                                  Apache License
                            Version 2.0, January 2004
@@ -974,8 +974,19 @@ Google Generative AI
    See the License for the specific language governing permissions and
    limitations under the License.
 
+==========================
+Anthropic SDK
+==========================
 
-------------------------------------------------------------------
+Copyright 2023 Anthropic, PBC.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+==========================-----------------------
 
 Bundled under the GPL Exceptions clause of PyInstaller
 
@@ -1074,7 +1085,7 @@ With this in mind, the following banner should be used in any source code file
 to indicate the copyright and license terms:
 
 
-#-----------------------------------------------------------------------------
+#==========================----------------------------------
 # Copyright (c) 2005-2023, PyInstaller Development Team.
 #
 # Distributed under the terms of the GNU General Public License (version 2
@@ -1083,10 +1094,10 @@ to indicate the copyright and license terms:
 # The full license is in the file COPYING.txt, distributed with this software.
 #
 # SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
-#-----------------------------------------------------------------------------
+#==========================----------------------------------
 
 
--------------------------------------------
+==========================
 
 Python is included in distributions in accordance with the PSF License Agreement
 

--- a/PySubtitle/Options.py
+++ b/PySubtitle/Options.py
@@ -8,6 +8,8 @@ from GUI.GuiHelpers import LoadInstructionsResource
 from PySubtitle.Instructions import Instructions
 from PySubtitle.version import __version__
 
+MULTILINE_OPTION = 'multiline'
+
 config_dir = appdirs.user_config_dir("GPTSubtrans", "MachineWrapped", roaming=True)
 settings_path = os.path.join(config_dir, 'settings.json')
 

--- a/PySubtitle/Providers/Local/LocalClient.py
+++ b/PySubtitle/Providers/Local/LocalClient.py
@@ -1,0 +1,120 @@
+import logging
+import time
+import httpx
+
+from PySubtitle.Helpers import FormatMessages
+from PySubtitle.SubtitleError import TranslationError, TranslationImpossibleError, TranslationResponseError
+from PySubtitle.Translation import Translation
+from PySubtitle.TranslationClient import TranslationClient
+from PySubtitle.TranslationParser import TranslationParser
+from PySubtitle.TranslationPrompt import TranslationPrompt
+
+class LocalClient(TranslationClient):
+    """
+    Handles communication with local LLM server to request translations
+    """
+    def __init__(self, settings : dict):
+        super().__init__(settings)
+
+        logging.info(f"Translating with local server at {self.server_address}{self.endpoint}")
+
+        self.client = httpx.Client(base_url=self.server_address, follow_redirects=True, timeout=300.0, headers={'Content-Type': 'application/json'})
+
+    @property
+    def server_address(self):
+        return self.settings.get('server_address')
+    
+    @property
+    def endpoint(self):
+        return self.settings.get('endpoint')
+    
+    @property
+    def supports_conversation(self):
+        return self.settings.get('supports_conversation', False)
+    
+    def _request_translation(self, prompt : TranslationPrompt, temperature : float = None) -> Translation:
+        """
+        Request a translation based on the provided prompt
+        """
+        logging.debug(f"Messages:\n{FormatMessages(prompt.messages)}")
+
+        temperature = temperature or self.temperature
+        response = self._make_request(prompt, temperature)
+
+        translation = Translation(response) if response else None
+
+        return translation
+
+    def GetParser(self):
+        return TranslationParser(self.settings)
+
+    def _abort(self):
+        if self.client:
+            self.client.close()
+        return super()._abort()
+
+    def _make_request(self, prompt : TranslationPrompt, temperature):
+        """
+        Make a request to the server to provide a translation
+        """
+        response = {}
+
+        try:
+            request_body = self._generate_request_body(prompt, temperature)
+            logging.debug(f"Request Body:\n{request_body}")
+
+            result : httpx.Response = self.client.post(self.endpoint, json=request_body)
+
+            if self.aborted:
+                return None
+            
+            logging.debug(f"Response:\n{result.text}")
+
+            content = result.json()
+
+            response['model'] = content.get('model')
+            response['response_time'] = content.get('response_ms', 0)
+
+            usage = content.get('usage', {})
+            response['prompt_tokens'] = usage.get('prompt_tokens')
+            response['output_tokens'] = usage.get('completion_tokens')
+            response['total_tokens'] = usage.get('total_tokens')
+
+            choices = content.get('choices')
+            if not choices:
+                raise TranslationResponseError("No choices returned in the response", response=result)
+
+            for choice in choices:
+                text = choice.get('text')
+                if text:
+                    response['text'] = text
+                    response['finish_reason'] = choice.get('finish_reason')
+                    break
+            
+            if not response.get('text'):
+                raise TranslationResponseError("No text returned in the response", response=result)
+
+            # Return the response if the API call succeeds
+            return response
+        
+        except httpx.NetworkError as e:
+            if not self.aborted:
+                raise TranslationError(str(e), error=e)
+
+        except Exception as e:
+            raise TranslationImpossibleError(f"Unexpected error communicating with Server", error=e)
+
+    def _generate_request_body(self, prompt, temperature):
+        request_body = {
+            'temperature': temperature,
+            'max_tokens': -1,
+            'stream': False
+        }
+
+        if self.supports_conversation:
+            request_body['messages'] = prompt.messages
+        else:
+            request_body['prompt'] = prompt.content
+
+        return request_body
+

--- a/PySubtitle/Providers/Local/LocalClient.py
+++ b/PySubtitle/Providers/Local/LocalClient.py
@@ -28,6 +28,10 @@ class LocalClient(TranslationClient):
         return self.settings.get('endpoint')
     
     @property
+    def api_key(self):
+        return self.settings.get('api_key')
+    
+    @property
     def supports_conversation(self):
         return self.settings.get('supports_conversation', False)
     
@@ -138,6 +142,9 @@ class LocalClient(TranslationClient):
             'max_tokens': max_tokens,
             'stream': False
         }
+
+        if self.api_key:
+            request_body['api_key'] = self.api_key
 
         if self.supports_conversation:
             request_body['messages'] = prompt.messages

--- a/PySubtitle/Providers/Local/LocalClient.py
+++ b/PySubtitle/Providers/Local/LocalClient.py
@@ -67,7 +67,8 @@ class LocalClient(TranslationClient):
                 return None
 
             try:
-                request_body = self._generate_request_body(prompt, temperature, self.max_tokens)
+                max_tokens = self.max_tokens if self.max_tokens else -1
+                request_body = self._generate_request_body(prompt, temperature, max_tokens)
                 logging.debug(f"Request Body:\n{request_body}")
 
                 self.client = httpx.Client(base_url=self.server_address, follow_redirects=True, timeout=300.0, headers={'Content-Type': 'application/json'})

--- a/PySubtitle/Providers/Provider_Local.py
+++ b/PySubtitle/Providers/Provider_Local.py
@@ -1,0 +1,56 @@
+
+import os
+from copy import deepcopy
+
+from PySubtitle.Helpers import GetEnvFloat
+from PySubtitle.TranslationClient import TranslationClient
+from PySubtitle.TranslationParser import TranslationParser
+from PySubtitle.TranslationProvider import TranslationProvider
+from PySubtitle.Providers.Local.LocalClient import LocalClient
+
+class Provider_LocalServer(TranslationProvider):
+    name = "Local Server"
+
+    information = """
+    <p>Connect to a local LLM server with an OpenAI compatible API.</p>
+    """
+
+    def __init__(self, settings : dict):
+        super().__init__(self.name, {
+            "server_address": settings.get('server_address') or os.getenv('LOCAL_SERVER_ADDRESS', "http://localhost:1234/v1"),
+            "endpoint": "/v1/chat/completions",
+            "supports_conversation": True,
+            "supports_system_messages": True,
+            'temperature': settings.get('temperature', GetEnvFloat('LOCAL_TEMPERATURE', 0.0))
+            })
+        
+        #TODO: Add additional parameters option
+        #TODO: Add support for custom prompt format
+        #TODO: Add support for custom response parser
+        self.refresh_when_changed = ['server_address']
+        
+    def GetTranslationClient(self, settings : dict) -> TranslationClient:
+        client_settings : dict = deepcopy(self.settings)
+        client_settings.update(settings)
+        return LocalClient(client_settings)
+    
+    def GetAvailableModels(self) -> list[str]:
+        # Choose the model on the server
+        return []
+    
+    def GetParser(self):
+        return TranslationParser(self.settings)
+    
+    def GetInformation(self):
+        return self.information
+    
+    def GetOptions(self) -> dict:
+        options = {
+            'server_address': (str, "The address of the local server"),
+            'endpoint': (str, "The endpoint to use on the server"),
+            'supports_conversation': (bool, "Specify whether the server supports chat format requests (default true)"),
+            'supports_system_messages': (bool, "Specify whether the server supports system messages (default true)"),
+            'temperature': (float, "Higher temperature introduces more randomness to the translation (default 0.0)"),
+        }
+
+        return options

--- a/PySubtitle/Providers/Provider_Local.py
+++ b/PySubtitle/Providers/Provider_Local.py
@@ -36,7 +36,8 @@ class Provider_LocalServer(TranslationProvider):
             'prompt_template': settings.get('prompt_template', os.getenv('LOCAL_PROMPT_TEMPLATE', TranslationPrompt.default_template)),
             'temperature': settings.get('temperature', GetEnvFloat('LOCAL_TEMPERATURE', 0.0)),
             'max_tokens': settings.get('max_tokens', GetEnvInteger('LOCAL_MAX_TOKENS', 0)),
-            "api_key": settings.get('api_key', os.getenv('LOCAL_API_KEY'))
+            "api_key": settings.get('api_key', os.getenv('LOCAL_API_KEY')),
+            "model": settings.get('model', os.getenv('LOCAL_MODEL'))
             })
         
         #TODO: Add additional parameters option

--- a/PySubtitle/Providers/Provider_Local.py
+++ b/PySubtitle/Providers/Provider_Local.py
@@ -33,7 +33,6 @@ class Provider_LocalServer(TranslationProvider):
             })
         
         #TODO: Add additional parameters option
-        #TODO: Add support for custom prompt format
         #TODO: Add support for custom response parser
         self.refresh_when_changed = ['server_address', 'supports_conversation']
         

--- a/PySubtitle/Providers/Provider_Local.py
+++ b/PySubtitle/Providers/Provider_Local.py
@@ -101,7 +101,9 @@ class Provider_LocalServer(TranslationProvider):
             options.update({
                 'prompt_template': (MULTILINE_OPTION, "Template for the prompt to send to the server (use {prompt} and {context} tags)"),
                 'temperature': (float, "Higher temperature introduces more randomness to the translation (default 0.0)"),
-                'max_tokens': (int, "The maximum number of tokens the AI should generate in the response (0 for unlimited)")
+                'max_tokens': (int, "The maximum number of tokens the AI should generate in the response (0 for unlimited)"),
+                'api_key': (str, "An API key is normally not needed for a local server"),
+                'model': (str, "The model is normally set by the server, and should not need to be specified here")
             })
 
         return options

--- a/PySubtitle/Providers/Provider_Local.py
+++ b/PySubtitle/Providers/Provider_Local.py
@@ -35,7 +35,8 @@ class Provider_LocalServer(TranslationProvider):
             'supports_system_messages': settings.get('supports_system_messages', GetEnvBool('LOCAL_SUPPORTS_SYSTEM_MESSAGES', True)),
             'prompt_template': settings.get('prompt_template', os.getenv('LOCAL_PROMPT_TEMPLATE', TranslationPrompt.default_template)),
             'temperature': settings.get('temperature', GetEnvFloat('LOCAL_TEMPERATURE', 0.0)),
-            'max_tokens': settings.get('max_tokens', GetEnvInteger('LOCAL_MAX_TOKENS', 0))
+            'max_tokens': settings.get('max_tokens', GetEnvInteger('LOCAL_MAX_TOKENS', 0)),
+            "api_key": settings.get('api_key', os.getenv('LOCAL_API_KEY'))
             })
         
         #TODO: Add additional parameters option
@@ -49,6 +50,10 @@ class Provider_LocalServer(TranslationProvider):
     @property
     def endpoint(self):
         return self.settings.get('endpoint')
+    
+    @property
+    def api_key(self):
+        return self.settings.get('api_key')
     
     @property
     def supports_conversation(self):

--- a/PySubtitle/Providers/Provider_Local.py
+++ b/PySubtitle/Providers/Provider_Local.py
@@ -2,9 +2,11 @@
 import os
 from copy import deepcopy
 
-from PySubtitle.Helpers import GetEnvFloat
+from PySubtitle.Helpers import GetEnvFloat, GetEnvInteger, GetEnvBool
+from PySubtitle.Options import MULTILINE_OPTION
 from PySubtitle.TranslationClient import TranslationClient
 from PySubtitle.TranslationParser import TranslationParser
+from PySubtitle.TranslationPrompt import TranslationPrompt
 from PySubtitle.TranslationProvider import TranslationProvider
 from PySubtitle.Providers.Local.LocalClient import LocalClient
 
@@ -12,23 +14,28 @@ class Provider_LocalServer(TranslationProvider):
     name = "Local Server"
 
     information = """
-    <p>Connect to a local LLM server with an OpenAI compatible API.</p>
+    <p>This provider allows you to connect to a server running locally (or otherwise accessible) with an OpenAI compatible API, 
+    e.g. <a href="https://lmstudio.ai/">LM Studio</a>.</p>
+    <p>The AI model to use as a translator should be specified on the server, which should then provide an address and supported endpoints.</p>
+    <p>Completion and chat endpoints are supported. For chat endpoints, indicate whether the server supports system messages.</p>
+    <p>Note that locally hosted models are likely to be much less capable than the large models hosted in the cloud, and results may be underwhelming.</p>
     """
 
     def __init__(self, settings : dict):
         super().__init__(self.name, {
-            "server_address": settings.get('server_address') or os.getenv('LOCAL_SERVER_ADDRESS', "http://localhost:1234"),
-            "endpoint": "/v1/chat/completions",
-            "supports_conversation": True,
-            "supports_system_messages": True,
+            'server_address': settings.get('server_address', os.getenv('LOCAL_SERVER_ADDRESS', "http://localhost:1234")),
+            'endpoint': settings.get('endpoint', os.getenv('LOCAL_ENDPOINT', "/v1/chat/completions")),
+            'supports_conversation': settings.get('supports_conversation', GetEnvBool('LOCAL_SUPPORTS_CONVERSATION', True)),
+            'supports_system_messages': settings.get('supports_system_messages', GetEnvBool('LOCAL_SUPPORTS_SYSTEM_MESSAGES', True)),
+            'prompt_template': settings.get('prompt_template', os.getenv('LOCAL_PROMPT_TEMPLATE', TranslationPrompt.default_template)),
             'temperature': settings.get('temperature', GetEnvFloat('LOCAL_TEMPERATURE', 0.0)),
-            'max_tokens': settings.get('max_tokens', GetEnvFloat('LOCAL_MAX_TOKENS', 2048))
+            'max_tokens': settings.get('max_tokens', GetEnvInteger('LOCAL_MAX_TOKENS', 0))
             })
         
         #TODO: Add additional parameters option
         #TODO: Add support for custom prompt format
         #TODO: Add support for custom response parser
-        self.refresh_when_changed = ['server_address']
+        self.refresh_when_changed = ['server_address', 'supports_conversation']
         
     def GetTranslationClient(self, settings : dict) -> TranslationClient:
         client_settings : dict = deepcopy(self.settings)
@@ -48,11 +55,17 @@ class Provider_LocalServer(TranslationProvider):
     def GetOptions(self) -> dict:
         options = {
             'server_address': (str, "The address of the local server"),
-            'endpoint': (str, "The endpoint to use on the server"),
-            'supports_conversation': (bool, "Specify whether the server supports chat format requests (default true)"),
-            'supports_system_messages': (bool, "Specify whether the server supports system messages (default true)"),
-            'temperature': (float, "Higher temperature introduces more randomness to the translation (default 0.0)"),
-            'max_tokens': (int, "The maximum number of tokens the AI should generate")
+            'endpoint': (str, "The API function to call on the server"),
+            'supports_conversation': (bool, "Attempt to communicate with the endpoint using chat format")
         }
+
+        if self.settings.get('supports_conversation'):
+            options['supports_system_messages'] = (bool, "Instructions will be sent as system messages rather than the user prompt")
+
+        options.update({
+            'prompt_template': (MULTILINE_OPTION, "Template for the prompt to send to the server (use {prompt} and {context} tags)"),
+            'temperature': (float, "Higher temperature introduces more randomness to the translation (default 0.0)"),
+            'max_tokens': (int, "The maximum number of tokens the AI should generate in the response (0 for unlimited)")
+        })
 
         return options

--- a/PySubtitle/Providers/Provider_Local.py
+++ b/PySubtitle/Providers/Provider_Local.py
@@ -17,11 +17,12 @@ class Provider_LocalServer(TranslationProvider):
 
     def __init__(self, settings : dict):
         super().__init__(self.name, {
-            "server_address": settings.get('server_address') or os.getenv('LOCAL_SERVER_ADDRESS', "http://localhost:1234/v1"),
+            "server_address": settings.get('server_address') or os.getenv('LOCAL_SERVER_ADDRESS', "http://localhost:1234"),
             "endpoint": "/v1/chat/completions",
             "supports_conversation": True,
             "supports_system_messages": True,
-            'temperature': settings.get('temperature', GetEnvFloat('LOCAL_TEMPERATURE', 0.0))
+            'temperature': settings.get('temperature', GetEnvFloat('LOCAL_TEMPERATURE', 0.0)),
+            'max_tokens': settings.get('max_tokens', GetEnvFloat('LOCAL_MAX_TOKENS', 2048))
             })
         
         #TODO: Add additional parameters option
@@ -51,6 +52,7 @@ class Provider_LocalServer(TranslationProvider):
             'supports_conversation': (bool, "Specify whether the server supports chat format requests (default true)"),
             'supports_system_messages': (bool, "Specify whether the server supports system messages (default true)"),
             'temperature': (float, "Higher temperature introduces more randomness to the translation (default 0.0)"),
+            'max_tokens': (int, "The maximum number of tokens the AI should generate")
         }
 
         return options

--- a/PySubtitle/TranslationClient.py
+++ b/PySubtitle/TranslationClient.py
@@ -31,7 +31,11 @@ class TranslationClient:
     @property
     def supports_system_messages(self):
         return self.settings.get('supports_system_messages', False)
-
+    
+    @property
+    def prompt_template(self):
+        return self.settings.get('prompt_template') or TranslationPrompt.default_template
+    
     @property
     def rate_limit(self):
         return self.settings.get('rate_limit')
@@ -47,6 +51,17 @@ class TranslationClient:
     @property
     def backoff_time(self):
         return self.settings.get('backoff_time', 5.0)
+    
+    def BuildTranslationPrompt(self, user_prompt : str, instructions : str, lines : list, context : dict):
+        """
+        Generate a translation prompt for the context
+        """
+        prompt = TranslationPrompt(user_prompt, self.supports_conversation)
+        prompt.supports_system_prompt = self.supports_system_prompt
+        prompt.supports_system_messages = self.supports_conversation and self.supports_system_messages
+        prompt.template = self.prompt_template
+        prompt.GenerateMessages(instructions, lines, context)
+        return prompt
 
     def RequestTranslation(self, prompt : TranslationPrompt, temperature : float = None) -> Translation:
         """

--- a/PySubtitle/TranslationPrompt.py
+++ b/PySubtitle/TranslationPrompt.py
@@ -1,13 +1,16 @@
-from PySubtitle.Helpers import GenerateBatchPrompt, GenerateTagLines, WrapSystemMessage
+from PySubtitle.Helpers import GenerateBatchPrompt, WrapSystemMessage
 from PySubtitle.SubtitleError import TranslationError
 
 class TranslationPrompt:
+    default_template = "<context>\n{context}\n</context>\n\n{prompt}\n\n<summary>Summary of the batch</summary>\n<scene>Summary of the scene</scene>\n"
+
     def __init__(self, user_prompt : str, conversation : bool = True, supports_system_prompt : bool = False, supports_system_messages : bool = False):
         self.conversation = conversation
         self.supports_system_prompt = supports_system_prompt
         self.supports_system_messages = supports_system_messages
-        self.system_prompt = None
         self.user_prompt = user_prompt
+        self.template = self.default_template
+        self.system_prompt = None
         self.batch_prompt = None
         self.content = None
         self.messages = []
@@ -21,13 +24,7 @@ class TranslationPrompt:
         user_role = "user"
         system_role = "system" if self.supports_system_messages else user_role
 
-        if context:
-            tag_lines = GenerateTagLines(context, ['description', 'names', 'history', 'scene', 'summary', 'batch'])
-
-            self.batch_prompt = GenerateBatchPrompt(self.user_prompt, lines, tag_lines)
-
-        else:
-            self.batch_prompt = GenerateBatchPrompt(self.user_prompt, lines)
+        self.batch_prompt = GenerateBatchPrompt(self.user_prompt, lines, context=context, template=self.template)
 
         if instructions:
             if self.supports_system_prompt:

--- a/llm-subtrans.cmd
+++ b/llm-subtrans.cmd
@@ -1,0 +1,10 @@
+@echo off
+
+rem Activate the virtual environment
+call envsubtrans\Scripts\activate.bat
+
+rem Run the script with the provided arguments
+python llm-subtrans.py %*
+
+rem Deactivate the virtual environment
+call envsubtrans\Scripts\deactivate

--- a/llm-subtrans.py
+++ b/llm-subtrans.py
@@ -1,0 +1,135 @@
+import os
+import argparse
+import logging
+
+from PySubtitle.Helpers import ParseNames, ParseSubstitutions
+from PySubtitle.Options import Options
+from PySubtitle.SubtitleProject import SubtitleProject
+from PySubtitle.SubtitleTranslator import SubtitleTranslator
+from PySubtitle.TranslationProvider import TranslationProvider
+
+provider = "Local Server"
+
+log_path = os.path.join(os.getcwd(), 'local-subtrans.log')
+level_name = os.getenv('LOG_LEVEL', 'INFO').upper()
+logging_level = getattr(logging, level_name, logging.INFO)
+
+# Create console logger
+try:
+    logging.basicConfig(format='%(levelname)s: %(message)s', encoding='utf-8', level=logging_level)
+    logging.info("Initialising log")
+
+except Exception as e:
+    logging.basicConfig(format='%(levelname)s: %(message)s', level=logging_level)
+    logging.info("Unable to write to utf-8 log, falling back to default encoding")
+
+# Create file handler with the same logging level
+try:
+    file_handler = logging.FileHandler(log_path, encoding='utf-8', mode='w')
+    formatter = logging.Formatter('%(levelname)s: %(message)s')
+    file_handler.setFormatter(formatter)
+    file_handler.setLevel(logging.INFO)
+    logging.getLogger('').addHandler(file_handler)
+except Exception as e:
+    logging.warning(f"Unable to create log file at {log_path}: {e}")
+
+# Parse command line arguments
+parser = argparse.ArgumentParser(description='Translates an SRT file using a local server')
+parser.add_argument('input', help="Input SRT file path")
+parser.add_argument('-o', '--output', help="Output SRT file path")
+parser.add_argument('-l', '--target_language', type=str, default=None, help="The target language for the translation")
+parser.add_argument('-s', '--server', type=str, default=None, help="Address of the server including port (e.g. http://localhost:1234)")
+parser.add_argument('-e', '--endpoint', type=str, default=None, help="Endpoint to call on  the server (e.g. /v1/completions)")
+parser.add_argument('-k', '--apikey', type=str, default=None, help="API Key, if required")
+
+parser.add_argument('--batchthreshold', type=float, default=None, help="Number of seconds between lines to consider for batching")
+parser.add_argument('--chat', action='store_true', help="Use chat format requests for the endpoint")
+parser.add_argument('--debug', action='store_true', help="Run with DEBUG log level")
+parser.add_argument('--description', type=str, default=None, help="A brief description of the film to give context")
+parser.add_argument('--includeoriginal', action='store_true', help="Include the original text in the translated subtitles")
+parser.add_argument('--instruction', action='append', type=str, default=None, help="An instruction for the AI translator")
+parser.add_argument('--instructionfile', type=str, default=None, help="Name/path of a file to load instructions from")
+parser.add_argument('--matchpartialwords', action='store_true', help="Allow substitutions that do not match not on word boundaries")
+parser.add_argument('--maxbatchsize', type=int, default=None, help="Maximum number of lines before starting a new batch is compulsory")
+parser.add_argument('--maxlines', type=int, default=None, help="Maximum number of lines(subtitles) to process in this run")
+parser.add_argument('--maxsummaries', type=int, default=None, help="Maximum number of context summaries to provide with each batch")
+parser.add_argument('--minbatchsize', type=int, default=None, help="Minimum number of lines to consider starting a new batch")
+parser.add_argument('--moviename', type=str, default=None, help="Optionally specify the name of the movie to help the translator")
+parser.add_argument('--name', action='append', type=str, default=None, help="A name to use verbatim in the translation")
+parser.add_argument('--names', type=str, default=None, help="A list of names to use verbatim")
+parser.add_argument('--project', type=str, default=None, help="Read or Write project file to working directory")
+parser.add_argument('--ratelimit', type=int, default=None, help="Maximum number of batches per minute to process")
+parser.add_argument('--scenethreshold', type=float, default=None, help="Number of seconds between lines to consider a new scene")
+parser.add_argument('--substitution', action='append', type=str, default=None, help="A pair of strings separated by ::, to subsitute in source or translation")
+parser.add_argument('--systemmessages', action='store_true', help="Indicates that the endpoint supports system messages in chat requests")
+parser.add_argument('--temperature', type=float, default=0.0, help="A higher temperature increases the random variance of translations.")
+parser.add_argument('--writebackup', action='store_true', help="Write a backup of the project file when it is loaded (if it exists)")
+
+args = parser.parse_args()
+
+if args.debug:
+    logging.getLogger('').setLevel(logging.DEBUG)
+    logging.debug("Debug logging enabled")
+
+try:
+    options = Options({
+        'api_key': args.apikey,
+        'batch_threshold': args.batchthreshold,
+        'description': args.description,
+        'endpoint': args.endpoint,
+        'include_original': args.includeoriginal,
+        'instruction_args': args.instruction,
+        'instruction_file': args.instructionfile,
+        'match_partial_words': args.matchpartialwords,
+        'max_batch_size': args.maxbatchsize,
+        'max_context_summaries': args.maxsummaries,
+        'max_lines': args.maxlines,
+        'min_batch_size': args.minbatchsize,
+        'movie_name': args.moviename or os.path.splitext(os.path.basename(args.input))[0],
+        'names': ParseNames(args.names or args.name),
+        'project': args.project and args.project.lower(),
+        'provider': provider,
+        'rate_limit': args.ratelimit,
+        'scene_threshold': args.scenethreshold,
+        'server_address': args.server,
+        'substitutions': ParseSubstitutions(args.substitution),
+        'supports_conversation': args.chat,
+        'supports_system_messages': args.systemmessages,
+        'target_language': args.target_language,
+        'temperature': args.temperature,
+        'write_backup': args.writebackup,
+    })
+
+    # Update provider settings with any relevant command line arguments
+    translation_provider = TranslationProvider.get_provider(options)
+    if not translation_provider:
+        raise ValueError(f"Unable to create translation provider {options.provider}")
+
+    if not translation_provider.ValidateSettings():
+        logging.error(f"Provider settings are not valid: {translation_provider.validation_message}")
+        raise ValueError(f"Invalid settings for provider {options.provider}")
+
+    logging.info(f"Using translation provider {translation_provider.name}")
+
+    # Load the instructions
+    options.InitialiseInstructions()
+
+    # Process the project options
+    project = SubtitleProject(options)
+
+    project.InitialiseProject(args.input, args.output, args.writebackup)
+    project.UpdateProjectSettings(options)
+
+    logging.info(f"Translating {project.subtitles.linecount} subtitles from {args.input}")
+
+    translator = SubtitleTranslator(options, translation_provider)
+
+    project.TranslateSubtitles(translator)
+
+    if project.write_project:
+        logging.info(f"Writing project data to {str(project.projectfile)}")
+        project.WriteProjectFile()
+
+except Exception as e:
+    print("Error:", e)
+    raise

--- a/llm-subtrans.py
+++ b/llm-subtrans.py
@@ -41,6 +41,7 @@ parser.add_argument('-l', '--target_language', type=str, default=None, help="The
 parser.add_argument('-s', '--server', type=str, default=None, help="Address of the server including port (e.g. http://localhost:1234)")
 parser.add_argument('-e', '--endpoint', type=str, default=None, help="Endpoint to call on  the server (e.g. /v1/completions)")
 parser.add_argument('-k', '--apikey', type=str, default=None, help="API Key, if required")
+parser.add_argument('-m', '--model', type=str, default=None, help="Model to use if the server allows it to be specified")
 
 parser.add_argument('--batchthreshold', type=float, default=None, help="Number of seconds between lines to consider for batching")
 parser.add_argument('--chat', action='store_true', help="Use chat format requests for the endpoint")
@@ -85,6 +86,7 @@ try:
         'max_context_summaries': args.maxsummaries,
         'max_lines': args.maxlines,
         'min_batch_size': args.minbatchsize,
+        'model': args.model,
         'movie_name': args.moviename or os.path.splitext(os.path.basename(args.input))[0],
         'names': ParseNames(args.names or args.name),
         'project': args.project and args.project.lower(),

--- a/readme.md
+++ b/readme.md
@@ -232,6 +232,9 @@ gpt-subtrans path/to/my/subtitles.srt --moviename "My Awesome Movie" --ratelimit
 - `-k`, `--apikey`:
   Local servers shouldn't need an api key, but the option is provided in case it is needed for your setup.
 
+- `-m`, `--model`:
+  The model will usually be determined by the server, but the option is provided in case you need to specify it.
+
 ## Project File
 
 **Note** If you are using the GUI a project file is created automatically when you open a subtitle file for the first time, and updated automatically.

--- a/readme.md
+++ b/readme.md
@@ -269,10 +269,12 @@ This project uses several useful libraries:
 - srt (https://github.com/cdown/srt)
 - requests (https://github.com/psf/requests)
 - regex (https://github.com/mrabarnett/mrab-regex)
+- httpx (https://github.com/projectdiscovery/httpx)
 
 Translation providers:
 - openai (https://platform.openai.com/docs/libraries/python-bindings)
 - google.generativeai (https://github.com/google/generative-ai-python)
+- anthropic (https://github.com/anthropics/anthropic-sdk-python)
 
 For the GUI:
 - pyside6 (https://wiki.qt.io/Qt_for_Python)

--- a/readme.md
+++ b/readme.md
@@ -56,7 +56,7 @@ For other platforms, or if you want to modify the program, you will need to have
 
 **The easiest setup method for most users is to run e.g. `install-openai.bat` or `install-gemini.bat` at this point and enter your API key when prompted. You can then skip the remaining steps. MacOS users should run `install.sh`, which will ask you to specify the provider (this should work on any unix-like system). **
 
-2. Create a new file named .env in the root directory of the project. Add your API key to the .env file like this:
+2. Create a new file named .env in the root directory of the project. Add any required settings for your chosen provider to the .env file like this:
 ```
     OPENAI_API_KEY=<your_openai_api_key>
     GEMINI_API_KEY=<your_gemini_api_key>
@@ -64,13 +64,12 @@ For other platforms, or if you want to modify the program, you will need to have
     CLAUDE_API_KEY=<your_claude_api_key>
 ```
 
-If you are using Azure, probably you want to add additional lines as well:
+If you are using Azure:
 
 ```
 AZURE_API_BASE=<your api_base, such as https://something.openai.azure.com>
 AZURE_DEPLOYMENT_NAME=<deployment_name>
 ```
-
 
 3. Create a virtual environment for the project by running the following command in the root folder to create a local environment for the Python interpreter.:
 ```
@@ -116,6 +115,7 @@ GPT-Subtrans can be used as a console command or shell script. The most basic us
 gpt-subtrans <path_to_srt_file> --target_language <target_language>
 gemini-subtrans <path_to_srt_file> --target_language <target_language>
 claude-subtrans <path_to_srt_file> --target_language <target_language>
+llm-subtrans -s <server_address> -e <endpoint> -l <language> <path_to_srt_file>
 ```
 
 This will activate the virtual environment and call the translation script with default parameters. If the target language is not specified the default is English.
@@ -215,6 +215,22 @@ gpt-subtrans path/to/my/subtitles.srt --moviename "My Awesome Movie" --ratelimit
 
 - `-m`, `--model`:
   Specify the [AI model](https://docs.anthropic.com/claude/docs/models-overview#model-comparison) to use for translation. This should be the full model name, e.g. `claude-3-haiku-20240307`
+
+### Local Server specific arguments
+- `-s`, `--server`:
+  The address the server is running on, including port (e.g. http://localhost:1234). Should be provided by the server
+
+- `-e`, `--endpoint`:
+  The API function to call on the server, e.g. `/v1/completions`. Choose an appropriate endpoint for the model running on the server.
+
+- `--chat`:
+  Specify this argument if the endpoint expects requests in a conversation format - otherwise it is assumed to be a completion endpoint.
+
+- `--systemmessages`:
+  If using a conversation endpoint, translation instructions will be sent as the "system" user if this flag is specified.
+
+- `-k`, `--apikey`:
+  Local servers shouldn't need an api key, but the option is provided in case it is needed for your setup.
 
 ## Project File
 


### PR DESCRIPTION
Not strictly a requirement that the server be local, but since there is no setting for an API key it's assumed to be at least a private instance.

The main difference is that the provider is more configurable, allowing selection of chat or completion endpoints and a customisable prompt template (TBD whether this is useful).

The provider handles its own requests using httpx, which means it is not dependent on any specific provider's SDK being installed.