### PR TITLE
Remove filler words

### DIFF
--- a/GUI/SettingsDialog.py
+++ b/GUI/SettingsDialog.py
@@ -53,6 +53,8 @@ class SettingsDialog(QDialog):
             'break_long_lines': (bool, "Add line breaks to long single lines (post-process)"),
             'max_single_line_length': (int, "Maximum length of a single line of subtitles"),
             'min_single_line_length': (int, "Minimum length of a single line of subtitles"),
+            'remove_filler_words': (bool, "Remove filler_words and filler words from subtitles"),
+            'filler_words': (str, "Comma-separated list of filler_words to remove"),
         },
         'Advanced': {
             'max_threads': (int, "Maximum number of simultaneous translation threads for fast translation"),

--- a/PySubtitle/Helpers/Text.py
+++ b/PySubtitle/Helpers/Text.py
@@ -5,7 +5,7 @@ whitespace_and_punctuation_pattern = regex.compile(r'[\p{P}\p{Z}\p{C}]')
 
 dialog_marker = "- "
 
-standard_filler_words = "um,umm,uh,uhh,er,err,ah,ahh,oh,eh,hm,hmm,huh,ha,mmm,ow,oww"
+standard_filler_words = "um,umm,uh,uhh,er,err,ah,ahh,oh,eh,hm,hmm,hmmm,huh,ha,mmm,ow,oww"
 
 priority_break_sequences = [
     regex.escape(dialog_marker),  # Dialog marker

--- a/PySubtitle/Helpers/Text.py
+++ b/PySubtitle/Helpers/Text.py
@@ -1,6 +1,8 @@
 import unicodedata
 import regex
 
+common_punctuation = r"[.,!?;:…¡¿]"
+
 whitespace_and_punctuation_pattern = regex.compile(r'[\p{P}\p{Z}\p{C}]')
 
 dialog_marker = "- "
@@ -212,8 +214,7 @@ def CompileFillerWordsPattern(filler_words: str | list[str]) -> regex.Pattern:
         return None
 
     filler_pattern = '|'.join(regex.escape(i) for i in filler_words if i)
-    punctuation = r"[.,!?]"
-    filler_words_pattern = rf"(^|[,]?\s+)({filler_pattern})({punctuation}+(\s+|$))"
+    filler_words_pattern = rf"(^|[,¡¿]?\s+)({filler_pattern})({common_punctuation}+(\s+|$))"
 
     return regex.compile(filler_words_pattern, flags=regex.IGNORECASE|regex.MULTILINE)
 

--- a/PySubtitle/Options.py
+++ b/PySubtitle/Options.py
@@ -4,7 +4,9 @@ import logging
 import os
 import dotenv
 import appdirs
+
 from PySubtitle.Instructions import Instructions, LoadInstructionsResource
+from PySubtitle.Helpers.Text import standard_filler_words
 from PySubtitle.version import __version__
 
 MULTILINE_OPTION = 'multiline'
@@ -46,6 +48,8 @@ default_options = {
     'min_line_duration': float(os.getenv('MIN_LINE_DURATION', 0.8)),
     'min_split_chars': int(os.getenv('MIN_SPLIT_CHARS', 3)),
     'normalise_dialog_tags': env_bool('NORMALISE_DIALOG_TAGS', True),
+    'remove_filler_words': env_bool('REMOVE_FILLER_WORDS', True),
+    'filler_words': standard_filler_words,
     'substitution_mode': os.getenv('SUBSTITUTION_MODE', "Auto"),
     'whitespaces_to_newline' : env_bool('WHITESPACES_TO_NEWLINE', False),
     'retry_on_error': env_bool('RETRY_ON_ERROR', True),

--- a/PySubtitle/UnitTests/test_text.py
+++ b/PySubtitle/UnitTests/test_text.py
@@ -4,9 +4,11 @@ import regex
 from PySubtitle.Helpers.Tests import log_input_expected_result, log_test_name
 from PySubtitle.Helpers.Text import (
     break_sequences,
+    standard_filler_words,
     BreakDialogOnOneLine,
     BreakLongLine,
     CompileDialogSplitPattern,
+    CompileFillerWordsPattern,
     ContainsTags,
     ExtractTag,
     ExtractTagList,
@@ -14,6 +16,7 @@ from PySubtitle.Helpers.Text import (
     LimitTextLength,
     Linearise,
     NormaliseDialogTags,
+    RemoveFillerWords,
     RemoveWhitespaceAndPunctuation,
     SanitiseSummary
     )
@@ -226,6 +229,24 @@ class TestTextHelpers(unittest.TestCase):
                 result = SanitiseSummary(text, movie_name, max_length)
                 log_input_expected_result(text, expected, result)
                 self.assertEqual(result, expected)
+
+    remove_filler_cases = [
+        ("This is a normal sentence", "This is a normal sentence"),
+        ("This is, err, not a normal sentence", "This is not a normal sentence"),
+        ("Umm, this sentence has a filler word", "This sentence has a filler word"),
+        ("This, err, sentence is, umm, full of filler words, eh?", "This sentence is full of filler words"),
+        ("This sentence has no filler. Ah, but this one does.", "This sentence has no filler. But this one does.")
+    ]
+
+    def test_RemoveFillerWords(self):
+        log_test_name("RemoveFillerWords")
+        filler_patterns = CompileFillerWordsPattern(standard_filler_words)
+        for text, expected in self.remove_filler_cases:
+            with self.subTest(text=text):
+                result = RemoveFillerWords(text, filler_patterns)
+                log_input_expected_result(text, expected, result)
+                self.assertEqual(result, expected)
+
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Remove umms and ahhs from translations, attempting to retain appropriate punctuation and capitalisation.