### PR TITLE
Allow intentionally blank lines in translation

### DIFF
--- a/GUI/ViewModel/BatchItem.py
+++ b/GUI/ViewModel/BatchItem.py
@@ -14,7 +14,7 @@ from PySubtitle.TranslationPrompt import TranslationPrompt
 
 class BatchItem(ViewModelItem):
     """ Represents a subtitle batch in the view model"""
-    def __init__(self, scene_number, batch : SubtitleBatch, debug_view = False):
+    def __init__(self, scene_number : int, batch : SubtitleBatch, debug_view : bool = False):
         super(BatchItem, self).__init__(f"Scene {scene_number}, batch {batch.number}")
         self.scene = scene_number
         self.number = batch.number
@@ -74,31 +74,31 @@ class BatchItem(ViewModelItem):
         return self.batch_model.get('context')
 
     @property
-    def summary(self):
+    def summary(self) -> str:
         return self.batch_model.get('summary')
 
     @property
-    def response(self):
+    def response(self) -> str:
         return self.batch_model.get('response')
 
     @property
-    def prompt(self):
+    def prompt(self) -> str:
         return self.batch_model.get('prompt')
 
     @property
-    def first_line_number(self):
+    def first_line_number(self) -> int:
         if not self._first_line_num:
             self._update_first_and_last()
         return self._first_line_num
 
     @property
-    def last_line_number(self):
+    def last_line_number(self) -> int:
         if not self._last_line_num:
             self._update_first_and_last()
         return self._last_line_num
 
     @property
-    def has_errors(self):
+    def has_errors(self) -> bool:
         return True if self.batch_model.get('errors') else False
 
     def Update(self, update : dict):
@@ -204,7 +204,7 @@ class BatchItem(ViewModelItem):
         self._first_line_num = None
         self._last_line_num = None
 
-    def _get_errors(self, errors):
+    def _get_errors(self, errors) -> list[str]:
         if errors:
             if all(isinstance(e, Exception) for e in errors):
                 return [ str(e) for e in errors ]

--- a/GUI/ViewModel/LineItem.py
+++ b/GUI/ViewModel/LineItem.py
@@ -1,6 +1,6 @@
 from GUI.GuiHelpers import GetLineHeight
 from PySubtitle.Helpers import UpdateFields
-from PySubtitle.Helpers.Text import Linearise
+from PySubtitle.Helpers.Text import Linearise, emdash
 
 from GUI.ViewModel.ViewModelError import ViewModelError
 
@@ -57,7 +57,8 @@ class LineItem(QStandardItem):
 
     @property
     def translation(self) -> str:
-        return self.line_model.get('translation')
+        translation = self.line_model.get('translation', None)
+        return translation if translation else (emdash if translation is not None else None)
 
     @property
     def scene(self) -> int:

--- a/GUI/ViewModel/LineItem.py
+++ b/GUI/ViewModel/LineItem.py
@@ -8,7 +8,7 @@ from PySide6.QtCore import Qt
 from PySide6.QtGui import QStandardItem
 
 class LineItem(QStandardItem):
-    def __init__(self, line_number, model):
+    def __init__(self, line_number : int, model : dict):
         super(LineItem, self).__init__(f"Line {line_number}")
         self.number = line_number
         self.line_model = model
@@ -16,7 +16,7 @@ class LineItem(QStandardItem):
 
         self.setData(self.line_model, Qt.ItemDataRole.UserRole)
 
-    def Update(self, line_update):
+    def Update(self, line_update : dict):
         if not isinstance(line_update, dict):
             raise ViewModelError(f"Expected a dictionary, got a {type(line_update).__name__}")
 
@@ -36,33 +36,33 @@ class LineItem(QStandardItem):
         return f"{self.number}: {self.start} --> {self.end}"
 
     @property
-    def start(self):
+    def start(self) -> str:
         return self.line_model['start']
 
     @property
-    def end(self):
+    def end(self) -> str:
         return self.line_model['end']
 
     @property
-    def duration(self):
+    def duration(self) -> str:
         return self.line_model['duration']
 
     @property
-    def gap(self):
+    def gap(self) -> str:
         return self.line_model['gap']
 
     @property
-    def text(self):
+    def text(self) -> str:
         return self.line_model['text']
 
     @property
-    def translation(self):
+    def translation(self) -> str:
         return self.line_model.get('translation')
 
     @property
-    def scene(self):
+    def scene(self) -> int:
         return self.line_model.get('scene')
 
     @property
-    def batch(self):
+    def batch(self) -> int:
         return self.line_model.get('batch')

--- a/GUI/ViewModel/LineItem.py
+++ b/GUI/ViewModel/LineItem.py
@@ -7,6 +7,8 @@ from GUI.ViewModel.ViewModelError import ViewModelError
 from PySide6.QtCore import Qt
 from PySide6.QtGui import QStandardItem
 
+blank_line = f"<font color='lightgrey'>{emdash}</font>"
+
 class LineItem(QStandardItem):
     def __init__(self, line_number : int, model : dict):
         super(LineItem, self).__init__(f"Line {line_number}")
@@ -58,7 +60,11 @@ class LineItem(QStandardItem):
     @property
     def translation(self) -> str:
         translation = self.line_model.get('translation', None)
-        return translation if translation else (emdash if translation is not None else None)
+        return translation if translation else (blank_line if translation is not None else None)
+
+    @property
+    def translation_text(self) -> str:
+        return self.line_model.get('translation', None)
 
     @property
     def scene(self) -> int:

--- a/GUI/Widgets/Editors.py
+++ b/GUI/Widgets/Editors.py
@@ -68,7 +68,7 @@ class EditDialog(QDialog):
         Subclasses should override this method to add editable fields to the form layout
         """
         raise NotImplementedError
-    
+
     def UpdateModel(self):
         """
         Subclasses should override this method to update the model from the form
@@ -146,7 +146,7 @@ class EditSubtitleDialog(EditDialog):
         self.line = line
         self.model = {
             'original' : self.line.text if line else "",
-            'translated'  : self.line.translation if line else ""
+            'translated'  : self.line.translation_text if line else ""
         }
         super().__init__(self.model, parent, title=f"Line {self.line.number}: {self.line.start} --> {self.line.end}")
 
@@ -162,4 +162,3 @@ class EditSubtitleDialog(EditDialog):
     def UpdateModel(self):
         self.UpdateModelFromEditor('original')
         self.UpdateModelFromEditor('translated')
-        

--- a/PySubtitle/Helpers/Text.py
+++ b/PySubtitle/Helpers/Text.py
@@ -4,6 +4,7 @@ import regex
 common_punctuation = r"[.,!?;:…¡¿]"
 
 dialog_marker = "- "
+emdash = "—"
 
 standard_filler_words = "um,umm,uh,uhh,er,err,ah,ahh,oh,eh,hm,hmm,hmmm,huh,ha,mmm,ow,oww"
 

--- a/PySubtitle/SubtitleFile.py
+++ b/PySubtitle/SubtitleFile.py
@@ -423,16 +423,16 @@ class SubtitleFile:
 
     def Sanitise(self):
         """
-        Remove blank lines, empty batches and empty scenes
+        Remove invalid lines, empty batches and empty scenes
         """
         with self.lock:
             for scene in self.scenes:
                 scene.batches = [batch for batch in scene.batches if batch.originals]
 
                 for batch in scene.batches:
-                    batch.originals = [line for line in batch.originals if line.number and line.text]
+                    batch.originals = [line for line in batch.originals if line.number and line.start is not None]
                     if batch.translated:
-                        batch.translated = [line for line in batch.translated if line.number and line.text]
+                        batch.translated = [line for line in batch.translated if line.number and line.start is not None]
 
         self.scenes = [scene for scene in self.scenes if scene.batches]
 

--- a/PySubtitle/SubtitleLine.py
+++ b/PySubtitle/SubtitleLine.py
@@ -180,7 +180,7 @@ def CreateSrtSubtitle(item : srt.Subtitle | SubtitleLine | str) -> srt.Subtitle:
             start = srt.srt_timestamp_to_timedelta(raw_start)
             end = srt.srt_timestamp_to_timedelta(raw_end)
             item = srt.Subtitle(index, start, end, content, proprietary)
-        else:
-            logging.error(f"Failed to parse line: {line}")
+        elif item is not None:
+            logging.warning(f"Failed to parse line: {line}")
 
     return item

--- a/PySubtitle/SubtitleProcessor.py
+++ b/PySubtitle/SubtitleProcessor.py
@@ -158,10 +158,10 @@ class SubtitleProcessor:
         Normalise dialog markers.
         Add line breaks to long lines.
         """
-        if not line.text:
-            return
+        text = line.text.strip()
 
-        text = line.text
+        if not text:
+            return line
 
         if self.remove_filler_words:
             text = RemoveFillerWords(text, self.filler_words_pattern)

--- a/PySubtitle/SubtitleScene.py
+++ b/PySubtitle/SubtitleScene.py
@@ -231,12 +231,11 @@ def UnbatchScenes(scenes : list[SubtitleScene]):
 
     for i_scene, scene in enumerate(scenes):
         for i_batch, batch in enumerate(scene.batches):
-            batch_originals = batch.originals if batch.originals else []
-            batch_translations = batch.translated if batch.translated else []
-            batch_untranslated = batch.untranslated if batch.untranslated else []
-
-            originals.extend(batch_originals)
-            translations.extend(batch_translations)
-            untranslated.extend(batch_untranslated)
+            if batch.originals:
+                originals.extend(batch.originals)
+            if batch.translated:
+                translations.extend(batch.translated)
+            if batch.untranslated:
+                untranslated.extend(batch.untranslated)
 
     return originals, translations, untranslated


### PR DESCRIPTION
Removing filler words can sometimes result in a blank line in the translation, but that's usually for the best. 

Allow blank lines to be saved to projects and display them as a light emdash to distinguish them from lines that just haven't been translated.