### PR TITLE
Load/save instructions from app data folder

### DIFF
--- a/GUI/NewProjectSettings.py
+++ b/GUI/NewProjectSettings.py
@@ -8,7 +8,7 @@ from PySide6.QtWidgets import (QDialog, QVBoxLayout, QDialogButtonBox, QFormLayo
 from GUI.ProjectDataModel import ProjectDataModel
 from GUI.Widgets.OptionsWidgets import CreateOptionWidget, DropdownOptionWidget
 
-from PySubtitle.Instructions import GetInstructionFiles, LoadInstructionsResource
+from PySubtitle.Instructions import GetInstructionsFiles, LoadInstructions
 from PySubtitle.SubtitleBatcher import SubtitleBatcher
 from PySubtitle.SubtitleLine import SubtitleLine
 from PySubtitle.SubtitleProcessor import SubtitleProcessor
@@ -53,7 +53,7 @@ class NewProjectSettings(QDialog):
         self.OPTIONS['model'] = (available_models, self.OPTIONS['model'][1])
         self.settings['model'] = datamodel.selected_model
 
-        instruction_files = GetInstructionFiles()
+        instruction_files = GetInstructionsFiles()
         if instruction_files:
             self.OPTIONS['instruction_file'] = (instruction_files, self.OPTIONS['instruction_file'][1])
 
@@ -99,7 +99,7 @@ class NewProjectSettings(QDialog):
             if instructions_file:
                 logging.info(f"Project instructions set from {instructions_file}")
                 try:
-                    instructions = LoadInstructionsResource(instructions_file)
+                    instructions = LoadInstructions(instructions_file)
 
                     self.settings['prompt'] = instructions.prompt
                     self.settings['instructions'] = instructions.instructions
@@ -151,7 +151,7 @@ class NewProjectSettings(QDialog):
         instruction_file = self.fields['instruction_file'].GetValue()
         if instruction_file:
             try:
-                instructions = LoadInstructionsResource(instruction_file)
+                instructions = LoadInstructions(instruction_file)
                 self.fields['prompt'].SetValue(instructions.prompt)
                 if instructions.target_language:
                     self.fields['target_language'].SetValue(instructions.target_language)

--- a/GUI/SettingsDialog.py
+++ b/GUI/SettingsDialog.py
@@ -4,7 +4,7 @@ from PySide6.QtWidgets import (QDialog, QVBoxLayout, QTabWidget, QDialogButtonBo
 from GUI.GuiHelpers import ClearForm, GetThemeNames
 
 from GUI.Widgets.OptionsWidgets import CreateOptionWidget
-from PySubtitle.Instructions import GetInstructionFiles, LoadInstructionsResource
+from PySubtitle.Instructions import GetInstructionsFiles, LoadInstructions
 from PySubtitle.Options import Options
 from PySubtitle.Substitutions import Substitutions
 from PySubtitle.TranslationProvider import TranslationProvider
@@ -115,7 +115,7 @@ class SettingsDialog(QDialog):
         self.SECTIONS['General']['theme'] = ['default'] + GetThemeNames()
 
         # Query available instruction files
-        instruction_files = GetInstructionFiles()
+        instruction_files = GetInstructionsFiles()
         if instruction_files:
             self.SECTIONS['General']['instruction_file'] = instruction_files
 
@@ -371,7 +371,7 @@ class SettingsDialog(QDialog):
         instruction_file = self.widgets['instruction_file'].GetValue()
         if instruction_file:
             try:
-                instructions = LoadInstructionsResource(instruction_file)
+                instructions = LoadInstructions(instruction_file)
                 self.widgets['prompt'].SetValue(instructions.prompt)
                 if instructions.target_language:
                     self.widgets['target_language'].SetValue(instructions.target_language)

--- a/PySubtitle/Helpers/Resources.py
+++ b/PySubtitle/Helpers/Resources.py
@@ -1,6 +1,9 @@
 
 import os
 import sys
+import appdirs
+
+config_dir = appdirs.user_config_dir("GPTSubtrans", "MachineWrapped", roaming=True)
 
 def GetResourcePath(relative_path, *parts):
     """

--- a/PySubtitle/Options.py
+++ b/PySubtitle/Options.py
@@ -3,15 +3,14 @@ import json
 import logging
 import os
 import dotenv
-import appdirs
 
-from PySubtitle.Instructions import Instructions, LoadInstructionsResource
+from PySubtitle.Instructions import Instructions, LoadInstructions
+from PySubtitle.Helpers.Resources import config_dir
 from PySubtitle.Helpers.Text import standard_filler_words
 from PySubtitle.version import __version__
 
 MULTILINE_OPTION = 'multiline'
 
-config_dir = appdirs.user_config_dir("GPTSubtrans", "MachineWrapped", roaming=True)
 settings_path = os.path.join(config_dir, 'settings.json')
 default_user_prompt = "Translate these subtitles [ for movie][ to language]"
 
@@ -233,7 +232,7 @@ class Options:
         instruction_file = self.get('instruction_file')
         if instruction_file:
             try:
-                instructions = LoadInstructionsResource(instruction_file)
+                instructions = LoadInstructions(instruction_file)
                 self.options['prompt'] = instructions.prompt
                 self.options['instructions'] = instructions.instructions
                 self.options['retry_instructions'] = instructions.retry_instructions

--- a/PySubtitle/VersionCheck.py
+++ b/PySubtitle/VersionCheck.py
@@ -2,14 +2,13 @@ import os
 import datetime
 import logging
 import requests
-import appdirs
 
 from PySubtitle.version import __version__
+from PySubtitle.Helpers.Resources import config_dir
 
 repo_name = "gpt-subtrans"
 repo_owner = "machinewrapped"
 
-config_dir = appdirs.user_config_dir("GPTSubtrans", "MachineWrapped", roaming=True)
 last_check_file = os.path.join(config_dir, 'last_check.txt')
 
 def CheckIfUpdateAvailable():


### PR DESCRIPTION
Check in application resource directory and user data folder (e.g. `%appdata%\MachineWrapped\GPTSubtrans\instructions`) for instructions files and combine them into one list - user data takes precedence over application resource if the names are the same.

The user data path is used by default for loading and saving instructions files.