### PR TITLE
Fix Typo in README.md: Correct 'souce' to 'source'

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -95,7 +95,7 @@ notice： For linux user, the environment has already prepared during the instal
     ```sh
     .\envsubtrans\Scripts\activate
     .\envsubtrans\bin\activate
-    soure path/to/gpt-subtrans/envsubtrans/bin/activate    # for linux user
+    source path/to/gpt-subtrans/envsubtrans/bin/activate    # for linux user
     ```
 
 #### step5


### PR DESCRIPTION
This pull request addresses a minor typo in the README file under the instructions for activating the virtual environment. The word 'souce' was incorrectly used instead of 'source'.

Changes made:
* Corrected from:
`souce path/to/gpt-subtrans/envsubtrans/bin/activate    # for linux user`

* to:
`source path/to/gpt-subtrans/envsubtrans/bin/activate    # for linux user`
