### PR TITLE
Add missing dependency to google-genai pip package (google-api-core) in install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -113,7 +113,7 @@ case $provider_choice in
         install_provider "OpenAI" "OPENAI" "openai" "gpt-subtrans"
         ;;
     2)
-        install_provider "Google Gemini" "GEMINI" "google-genai" "gemini-subtrans"
+        install_provider "Google Gemini" "GEMINI" "google-genai google-api-core" "gemini-subtrans"
         ;;
     3)
         install_provider "Claude" "CLAUDE" "anthropic" "claude-subtrans"
@@ -129,7 +129,7 @@ case $provider_choice in
         ;;
     a)
         install_provider "Claude" "CLAUDE" "anthropic" "claude-subtrans"
-        install_provider "Google Gemini" "GEMINI" "google-genai" "gemini-subtrans"
+        install_provider "Google Gemini" "GEMINI" "google-genai google-api-core" "gemini-subtrans"
         install_provider "DeepSeek" "DEEPSEEK" "openai" "deepseek-subtrans"
         install_provider "Mistral", "MISTRAL" "mistralai" "mistral-subtrans"
         install_provider "OpenAI" "OPENAI" "openai" "gpt-subtrans"


### PR DESCRIPTION
The pip package google-genai needs google-api-core package to be installed as a dependency. This pull request is adding it to the list of packages to install when Gemini provider (or all) is selected during the install process.