### PR TITLE
break after truncating text

### DIFF
--- a/PySubtitle/TranslationParser.py
+++ b/PySubtitle/TranslationParser.py
@@ -189,3 +189,4 @@ class TranslationParser:
             if not regex.search(rf"</{tag}>", last_line.text):
                 logging.warning(f"Found unclosed tag {tag} in translation: {tag}")
                 last_line.text = last_line.text[:match.start()]
+                break

--- a/PySubtitle/TranslationParser.py
+++ b/PySubtitle/TranslationParser.py
@@ -190,3 +190,4 @@ class TranslationParser:
                 logging.warning(f"Found unclosed tag {tag} in translation: {tag}")
                 last_line.text = last_line.text[:match.start()]
                 break
+            


### PR DESCRIPTION
Break after modifying the text string to prevent invalidating the iterator. Spotted by @gemini-code-assist